### PR TITLE
Handle route updates without downtime

### DIFF
--- a/packages/wrangler/src/__tests__/deploy.test.ts
+++ b/packages/wrangler/src/__tests__/deploy.test.ts
@@ -1686,15 +1686,8 @@ describe("deploy", () => {
 				Existing routes for this Worker in such zones will not be deleted."
 			`);
 			expect(std.err).toMatchInlineSnapshot(`""`);
-			expect(std.warn).toMatchInlineSnapshot(`
-				"[33m▲ [43;33m[[43;30mWARNING[43;33m][0m [1mPreviously deployed routes:[0m
+			expect(std.warn).toMatchInlineSnapshot(`""`);
 
-				  The following routes were already associated with this worker, and have not been deleted:
-				   - \\"foo.example.com/other-route\\"
-				  If these routes are not wanted then you can remove them in the dashboard.
-
-				"
-			`);
 			expect(std.out).toMatchInlineSnapshot(`
 				"
 				 ⛅️ wrangler x.x.x
@@ -1733,12 +1726,95 @@ describe("deploy", () => {
 				pattern: "example.com/some-route/*",
 				script: "test-name",
 			});
-			await expect(runWrangler("deploy ./index --env=staging")).rejects
-				.toThrowErrorMatchingInlineSnapshot(`
-				[Error: Service environments combined with an API token that doesn't have 'All Zones' permissions is not supported.
-				Either turn off service environments by setting \`legacy_env = true\`, creating an API token with 'All Zones' permissions, or logging in via OAuth]
-			`);
+		await expect(runWrangler("deploy ./index --env=staging")).rejects
+			.toThrowErrorMatchingInlineSnapshot(`
+			[Error: Service environments combined with an API token that doesn't have 'All Zones' permissions is not supported.
+			Either turn off service environments by setting \`legacy_env = true\`, creating an API token with 'All Zones' permissions, or logging in via OAuth]
+		`);
+	});
+
+	it("updates an existing route in place when the pattern changes", async () => {
+		writeWranglerConfig({
+			routes: ["example.com/foo/*"],
 		});
+		writeWorkerSource();
+		mockUpdateWorkerSubdomain({ enabled: false });
+		mockUploadWorkerRequest({ expectedType: "esm" });
+		mockGetZones("example.com", [{ id: "example-com-id" }]);
+		mockGetZoneWorkerRoutes("example-com-id", [
+			{
+				id: "existing-route-id",
+				pattern: "example.com/*",
+				script: "test-name",
+			},
+		]);
+
+		msw.use(
+			http.get(
+				"*/accounts/:accountId/workers/services/:scriptName/routes",
+				({ params }) => {
+					expect(params.accountId).toEqual("some-account-id");
+					expect(params.scriptName).toEqual("test-name");
+					return HttpResponse.json(
+						createFetchResult([
+							{
+								id: "existing-route-id",
+								pattern: "example.com/*",
+								script: "test-name",
+								zone_id: "example-com-id",
+							},
+						])
+					);
+				},
+				{ once: true }
+			)
+		);
+
+		let updateCount = 0;
+		let createCount = 0;
+		let deleteCount = 0;
+
+		msw.use(
+			http.put(
+				"*/zones/:zoneId/workers/routes/:routeId",
+				async ({ params, request }) => {
+					updateCount++;
+					expect(params.routeId).toEqual("existing-route-id");
+					const body = await request.json();
+					expect(body.pattern).toEqual("example.com/foo/*");
+					expect(body.script).toEqual("test-name");
+					return HttpResponse.json(
+						createFetchResult({
+							id: params.routeId as string,
+							pattern: body.pattern,
+							script: body.script,
+						})
+					);
+				}
+			)
+		);
+
+		msw.use(
+			http.post("*/zones/:zoneId/workers/routes", () => {
+				createCount++;
+				return HttpResponse.json(createFetchResult(null));
+			})
+		);
+
+		msw.use(
+			http.delete("*/zones/:zoneId/workers/routes/:routeId", () => {
+				deleteCount++;
+				return HttpResponse.json(createFetchResult(null));
+			})
+		);
+
+		await runWrangler("deploy ./index");
+
+		expect(updateCount).toBe(1);
+		expect(createCount).toBe(0);
+		expect(deleteCount).toBe(0);
+		expect(std.out).toContain("example.com/foo/*");
+	});
 
 		describe("custom domains", () => {
 			it("should deploy routes marked with 'custom_domain' as separate custom domains", async () => {
@@ -16086,10 +16162,12 @@ function mockPublishSchedulesRequest({
 
 function mockPublishRoutesRequest({
 	routes = [],
+	existingRoutes = [],
 	env = undefined,
 	useServiceEnvironments = true,
 }: {
 	routes: Config["routes"];
+	existingRoutes?: { pattern: string; id?: string; zone_id?: string }[];
 	env?: string | undefined;
 	useServiceEnvironments?: boolean | undefined;
 }) {
@@ -16097,27 +16175,75 @@ function mockPublishRoutesRequest({
 		env && useServiceEnvironments ? "services" : "scripts";
 	const environment =
 		env && useServiceEnvironments ? "/environments/:envName" : "";
+	const expectedScriptName =
+		!useServiceEnvironments && env ? `test-name-${env}` : "test-name";
 
 	msw.use(
-		http.put(
+		http.get(
 			`*/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/routes`,
-			async ({ request, params }) => {
+			async ({ params }) => {
 				expect(params.accountId).toEqual("some-account-id");
-				expect(params.scriptName).toEqual(
-					!useServiceEnvironments && env ? `test-name-${env}` : "test-name"
-				);
+				expect(params.scriptName).toEqual(expectedScriptName);
 				if (useServiceEnvironments) {
 					expect(params.envName).toEqual(env);
 				}
-				const body = await request.json();
-				expect(body).toEqual(
-					routes.map((route) =>
-						typeof route !== "object" ? { pattern: route } : route
+				return HttpResponse.json(
+					createFetchResult(
+						existingRoutes.map((route) => ({
+							script: expectedScriptName,
+							...route,
+						}))
 					)
 				);
-				return HttpResponse.json(createFetchResult(null));
 			},
 			{ once: true }
+		)
+	);
+
+	msw.use(
+		http.post(
+			"*/zones/:zoneId/workers/routes",
+			async ({ request }) => {
+				const body = await request.json();
+				expect(body.script).toEqual(expectedScriptName);
+				if (routes.length > 0) {
+					const patterns = routes.map((route) =>
+						typeof route === "string" ? route : route.pattern
+					);
+					expect(patterns).toContain(body.pattern);
+				}
+				return HttpResponse.json(
+					createFetchResult({
+						id: `${body.pattern}-id`,
+						pattern: body.pattern,
+						script: body.script,
+					})
+				);
+			}
+		)
+	);
+
+	msw.use(
+		http.put(
+			"*/zones/:zoneId/workers/routes/:routeId",
+			async ({ request, params }) => {
+				expect(params.routeId).toBeDefined();
+				const body = await request.json();
+				expect(body.script).toEqual(expectedScriptName);
+				return HttpResponse.json(
+					createFetchResult({
+						id: params.routeId as string,
+						pattern: body.pattern,
+						script: body.script,
+					})
+				);
+			}
+		)
+	);
+
+	msw.use(
+		http.delete("*/zones/:zoneId/workers/routes/:routeId", () =>
+			HttpResponse.json(createFetchResult(null))
 		)
 	);
 }
@@ -16135,15 +16261,14 @@ function mockUnauthorizedPublishRoutesRequest({
 		env && useServiceEnvironments ? "/environments/:envName" : "";
 
 	msw.use(
-		http.put(
+		http.get(
 			`*/accounts/:accountId/workers/${servicesOrScripts}/:scriptName${environment}/routes`,
-			() => {
-				return HttpResponse.json(
+			() =>
+				HttpResponse.json(
 					createFetchResult(null, false, [
 						{ message: "Authentication error", code: 10000 },
 					])
-				);
-			},
+				),
 			{ once: true }
 		)
 	);
@@ -16153,6 +16278,18 @@ function mockPublishRoutesFallbackRequest(route: {
 	pattern: string;
 	script: string;
 }) {
+	msw.use(
+		http.put(
+			`*/zones/:zoneId/workers/routes/:routeId`,
+			async ({ request }) => {
+				const body = await request.json();
+				expect(body).toEqual(route);
+				return HttpResponse.json(createFetchResult(route.pattern));
+			},
+			{ once: true }
+		)
+	);
+
 	msw.use(
 		http.post(
 			`*/zones/:zoneId/workers/routes`,

--- a/packages/wrangler/src/__tests__/helpers/mock-zone-routes.ts
+++ b/packages/wrangler/src/__tests__/helpers/mock-zone-routes.ts
@@ -12,19 +12,22 @@ export function mockGetZoneWorkerRoutesMulti(
 	msw.use(
 		http.get<{ zoneId: string }>(
 			"*/zones/:zoneId/workers/routes",
-			({ params }) => {
-				expect(Object.keys(zones)).toContain(params.zoneId);
-				const routes = zones[params.zoneId] ?? [];
-				return HttpResponse.json(
-					{
-						success: true,
-						errors: [],
-						messages: [],
-						result: routes,
-					},
-					{ status: 200 }
-				);
-			},
+		({ params }) => {
+			expect(Object.keys(zones)).toContain(params.zoneId);
+			const routes = (zones[params.zoneId] ?? []).map((route, index) => ({
+				id: route.id ?? `route-${index}`,
+				...route,
+			}));
+			return HttpResponse.json(
+				{
+					success: true,
+					errors: [],
+					messages: [],
+					result: routes,
+				},
+				{ status: 200 }
+			);
+		},
 			options
 		)
 	);

--- a/packages/wrangler/src/deploy/deploy.ts
+++ b/packages/wrangler/src/deploy/deploy.ts
@@ -1233,17 +1233,10 @@ export async function publishRoutes(
 	}
 ): Promise<string[]> {
 	try {
-		return await fetchResult(complianceConfig, `${workerUrl}/routes`, {
-			// Note: PUT will delete previous routes on this script.
-			method: "PUT",
-			body: JSON.stringify(
-				routes.map((route) =>
-					typeof route !== "object" ? { pattern: route } : route
-				)
-			),
-			headers: {
-				"Content-Type": "application/json",
-			},
+		return await publishRoutesZeroDowntime(complianceConfig, routes, {
+			workerUrl,
+			scriptName,
+			accountId,
 		});
 	} catch (e) {
 		if (isAuthenticationError(e)) {
@@ -1261,6 +1254,38 @@ export async function publishRoutes(
 }
 
 /**
+ * Update routes for the Worker using the zone-based API to avoid downtime.
+ */
+
+type WorkerRouteWithZone = {
+	id: string;
+	pattern: string;
+	script: string;
+	zone_id?: string;
+};
+
+async function publishRoutesZeroDowntime(
+	complianceConfig: ComplianceConfig,
+	routes: Route[],
+	{
+		workerUrl,
+		scriptName,
+		accountId,
+	}: { workerUrl: string; scriptName: string; accountId: string }
+) {
+	const existingRouteAssignments = await fetchResult<WorkerRouteWithZone[]>(
+		complianceConfig,
+		`${workerUrl}/routes`
+	);
+	return await publishRoutesFallback(complianceConfig, routes, {
+		scriptName,
+		useServiceEnvironments: false,
+		accountId,
+		existingRouteAssignments,
+	});
+}
+
+/**
  * Try updating routes for the Worker using a less optimal zone-based API.
  *
  * Compute match zones to the routes, then for each route attempt to connect it to the Worker via the zone.
@@ -1272,7 +1297,13 @@ async function publishRoutesFallback(
 		scriptName,
 		useServiceEnvironments,
 		accountId,
-	}: { scriptName: string; useServiceEnvironments: boolean; accountId: string }
+		existingRouteAssignments,
+	}: {
+		scriptName: string;
+		useServiceEnvironments: boolean;
+		accountId: string;
+		existingRouteAssignments?: WorkerRouteWithZone[];
+	}
 ) {
 	if (useServiceEnvironments) {
 		throw new UserError(
@@ -1281,12 +1312,14 @@ async function publishRoutesFallback(
 			{ telemetryMessage: true }
 		);
 	}
-	logger.info(
-		"The current authentication token does not have 'All Zones' permissions.\n" +
-			"Falling back to using the zone-based API endpoint to update each route individually.\n" +
-			"Note that there is no access to routes associated with zones that the API token does not have permission for.\n" +
-			"Existing routes for this Worker in such zones will not be deleted."
-	);
+	if (!existingRouteAssignments) {
+		logger.info(
+			"The current authentication token does not have 'All Zones' permissions.\n" +
+				"Falling back to using the zone-based API endpoint to update each route individually.\n" +
+				"Note that there is no access to routes associated with zones that the API token does not have permission for.\n" +
+				"Existing routes for this Worker in such zones will not be deleted."
+		);
+	}
 
 	const deployedRoutes: string[] = [];
 
@@ -1294,9 +1327,8 @@ async function publishRoutesFallback(
 	const queuePromises: Array<Promise<void>> = [];
 	const zoneIdCache = new Map();
 
-	// Collect the routes (and their zones) that will be deployed.
-	const activeZones = new Map<string, string>();
-	const routesToDeploy = new Map<string, string>();
+	const desiredRoutesByZone = new Map<string, string[]>();
+	const zonesToInspect = new Map<string, string>();
 	for (const route of routes) {
 		queuePromises.push(
 			queue.add(async () => {
@@ -1306,37 +1338,54 @@ async function publishRoutesFallback(
 					zoneIdCache
 				);
 				if (zone) {
-					activeZones.set(zone.id, zone.host);
-					routesToDeploy.set(
-						typeof route === "string" ? route : route.pattern,
-						zone.id
-					);
+					zonesToInspect.set(zone.id, zone.host);
+					const pattern = typeof route === "string" ? route : route.pattern;
+					desiredRoutesByZone.set(zone.id, [
+						...(desiredRoutesByZone.get(zone.id) ?? []),
+						pattern,
+					]);
 				}
 			})
 		);
 	}
+
+	const resolvedExistingRoutes = existingRouteAssignments ?? [];
+	for (const existing of resolvedExistingRoutes) {
+		if (existing.zone_id) {
+			zonesToInspect.set(existing.zone_id, "");
+			continue;
+		}
+
+		queuePromises.push(
+			queue.add(async () => {
+				const zone = await getZoneForRoute(
+					complianceConfig,
+					{ route: existing.pattern, accountId },
+					zoneIdCache
+				);
+				if (zone) {
+					zonesToInspect.set(zone.id, zone.host);
+				}
+			})
+		);
+	}
+
 	await Promise.all(queuePromises.splice(0, queuePromises.length));
 
-	// Collect the routes that are already deployed.
-	const allRoutes = new Map<string, string>();
-	const alreadyDeployedRoutes = new Set<string>();
-	for (const [zone, host] of activeZones) {
+	const existingRoutesByZone = new Map<string, WorkerRouteWithZone[]>();
+	for (const [zoneId, host] of zonesToInspect) {
 		queuePromises.push(
 			queue.add(async () => {
 				try {
-					for (const { pattern, script } of await fetchListResult<{
-						pattern: string;
-						script: string;
-					}>(complianceConfig, `/zones/${zone}/workers/routes`)) {
-						allRoutes.set(pattern, script);
-						if (script === scriptName) {
-							alreadyDeployedRoutes.add(pattern);
-						}
-					}
+					const routesInZone = await fetchListResult<WorkerRouteWithZone>(
+						complianceConfig,
+						`/zones/${zoneId}/workers/routes`
+					);
+					existingRoutesByZone.set(zoneId, routesInZone);
 				} catch (e) {
 					if (isAuthenticationError(e)) {
 						e.notes.push({
-							text: `This could be because the API token being used does not have permission to access the zone "${host}" (${zone}).`,
+							text: `This could be because the API token being used does not have permission to access the zone "${host}" (${zoneId}).`,
 						});
 					}
 					throw e;
@@ -1344,54 +1393,117 @@ async function publishRoutesFallback(
 			})
 		);
 	}
-	// using Promise.all() here instead of queue.onIdle() to ensure
-	// we actually throw errors that occur within queued promises.
+
 	await Promise.all(queuePromises);
 
-	// Deploy each route that is not already deployed.
-	for (const [routePattern, zoneId] of routesToDeploy.entries()) {
-		if (allRoutes.has(routePattern)) {
-			const knownScript = allRoutes.get(routePattern);
-			if (knownScript === scriptName) {
-				// This route is already associated with this worker, so no need to hit the API.
-				alreadyDeployedRoutes.delete(routePattern);
-				continue;
-			} else {
-				throw new UserError(
-					`The route with pattern "${routePattern}" is already associated with another worker called "${knownScript}".`,
-					{ telemetryMessage: "route already associated with another worker" }
-				);
-			}
+	for (const [zoneId] of zonesToInspect) {
+		const desiredPatterns = desiredRoutesByZone.get(zoneId) ?? [];
+		const existingRoutes = existingRoutesByZone.get(zoneId) ?? [];
+		const { toCreate, toDelete, toUpdate, deployed } = planZoneRouteChanges(
+			desiredPatterns,
+			existingRoutes,
+			scriptName
+		);
+		deployedRoutes.push(...deployed);
+
+		for (const route of toUpdate) {
+			await fetchResult<WorkerRouteWithZone>(
+				complianceConfig,
+				`/zones/${zoneId}/workers/routes/${route.id}`,
+				{
+					method: "PUT",
+					body: JSON.stringify({
+						pattern: route.pattern,
+						script: scriptName,
+					}),
+					headers: {
+						"Content-Type": "application/json",
+					},
+				}
+			);
 		}
 
-		const { pattern } = await fetchResult<{ pattern: string }>(
-			complianceConfig,
-			`/zones/${zoneId}/workers/routes`,
-			{
+		for (const pattern of toCreate) {
+			const { pattern: createdPattern } = await fetchResult<{
+				pattern: string;
+			}>(complianceConfig, `/zones/${zoneId}/workers/routes`, {
 				method: "POST",
 				body: JSON.stringify({
-					pattern: routePattern,
+					pattern,
 					script: scriptName,
 				}),
 				headers: {
 					"Content-Type": "application/json",
 				},
-			}
-		);
+			});
+			deployedRoutes.push(createdPattern);
+		}
 
-		deployedRoutes.push(pattern);
-	}
-
-	if (alreadyDeployedRoutes.size) {
-		logger.warn(
-			"Previously deployed routes:\n" +
-				"The following routes were already associated with this worker, and have not been deleted:\n" +
-				[...alreadyDeployedRoutes.values()].map((route) => ` - "${route}"\n`) +
-				"If these routes are not wanted then you can remove them in the dashboard."
-		);
+		for (const routeId of toDelete) {
+			await fetchResult(
+				complianceConfig,
+				`/zones/${zoneId}/workers/routes/${routeId}`,
+				{ method: "DELETE" }
+			);
+		}
 	}
 
 	return deployedRoutes;
+}
+
+function planZoneRouteChanges(
+	desiredPatterns: string[],
+	existingRoutes: WorkerRouteWithZone[],
+	scriptName: string
+) {
+	const deployed: string[] = [];
+	const toCreate: string[] = [];
+	const toDelete: string[] = [];
+	const toUpdate: Array<{ id: string; pattern: string }> = [];
+
+	const matchedRouteIds = new Set<string>();
+
+	for (const pattern of desiredPatterns) {
+		const existingMatch = existingRoutes.find(
+			(route) => route.pattern === pattern
+		);
+		if (existingMatch) {
+			if (existingMatch.script !== scriptName) {
+				throw new UserError(
+					`The route with pattern "${pattern}" is already associated with another worker called "${existingMatch.script}".`,
+					{ telemetryMessage: "route already associated with another worker" }
+				);
+			}
+			matchedRouteIds.add(existingMatch.id);
+			deployed.push(pattern);
+		}
+	}
+
+	const reusableRoutes = existingRoutes.filter(
+		(route) => route.script === scriptName && !matchedRouteIds.has(route.id)
+	);
+	const unmatchedDesired = desiredPatterns.filter(
+		(pattern) => !deployed.includes(pattern)
+	);
+
+	for (const pattern of unmatchedDesired) {
+		const routeToUpdate = reusableRoutes.shift();
+		if (routeToUpdate) {
+			toUpdate.push({ id: routeToUpdate.id, pattern });
+			deployed.push(pattern);
+		} else {
+			toCreate.push(pattern);
+		}
+	}
+
+	const updatedRouteIds = new Set(toUpdate.map((route) => route.id));
+	for (const route of reusableRoutes) {
+		if (!updatedRouteIds.has(route.id)) {
+			toDelete.push(route.id);
+		}
+	}
+
+	return { toCreate, toDelete, toUpdate, deployed };
 }
 
 export function isAuthenticationError(e: unknown): e is ParseError {


### PR DESCRIPTION
## Summary
- update route publishing to reuse existing assignments and apply changes per zone to avoid downtime
- refresh route-related mocks to include route ids and support zero-downtime operations
- add coverage ensuring route pattern changes update existing routes instead of deleting them

## Testing
- pnpm --filter wrangler test -- --runInBand deploy.test.ts --testNamePattern "updates an existing route in place when the pattern changes" *(fails: `dotenv` command not found in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940a50095a48332a202d7d179258fb6)