### PR TITLE
[wrangler] Show API status in error notes

### DIFF
--- a/.changeset/slow-apes-guess.md
+++ b/.changeset/slow-apes-guess.md
@@ -1,0 +1,5 @@
+---
+"wrangler": patch
+---
+
+Add API error status notes to improve debugging.

--- a/packages/wrangler/src/__tests__/match-tag.test.ts
+++ b/packages/wrangler/src/__tests__/match-tag.test.ts
@@ -131,6 +131,7 @@ describe("match-tag", () => {
 				`
 				[Error: An error occurred while trying to validate that the Worker name matches what is expected by the build system.
 				A request to the Cloudflare API (/accounts/some-account-id/workers/services/auth-error-worker) failed.
+				Status 401
 				Authentication error [code: 10000]]
 			`
 			);
@@ -206,6 +207,7 @@ describe("match-tag", () => {
 					`
 					[Error: An error occurred while trying to validate that the Worker name matches what is expected by the build system.
 					A request to the Cloudflare API (/accounts/some-account-id/workers/services/auth-error-worker) failed.
+					Status 401
 					Authentication error [code: 10000]]
 				`
 				);

--- a/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
+++ b/packages/wrangler/src/__tests__/pages/pages-download-config.test.ts
@@ -847,6 +847,7 @@ describe("pages download config", () => {
 			  "debug": "",
 			  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/MOCK_ACCOUNT_ID/pages/projects/NOT_REAL) failed.[0m
 
+			  Status 404
 			  Project not found. The specified project name does not match any of your existing projects. [code:
 			  8000007]
 

--- a/packages/wrangler/src/__tests__/queues/queues.test.ts
+++ b/packages/wrangler/src/__tests__/queues/queues.test.ts
@@ -993,6 +993,8 @@ describe("wrangler", () => {
 
 				�[31mX �[41;31m[�[41;97mERROR�[41;31m]�[0m �[1mA request to the Cloudflare API (/accounts/some-account-id/queues/testQueue/consumers) failed.�[0m
 
+				  Status 403
+
 				  workers.api.error.unauthorized [code: 10023]
 
 				  If you think this is a bug, please open an issue at:

--- a/packages/wrangler/src/__tests__/r2/bucket.test.ts
+++ b/packages/wrangler/src/__tests__/r2/bucket.test.ts
@@ -422,6 +422,7 @@ describe("r2", () => {
 					  "debug": "",
 					  "err": "[31mX [41;31m[[41;97mERROR[41;31m][0m [1mA request to the Cloudflare API (/accounts/some-account-id/r2/buckets) failed.[0m
 
+					  Status 400
 					  The JSON you provided was not well formed. [code: 10040]
 
 					  If you think this is a bug, please open an issue at:

--- a/packages/wrangler/src/cfetch/index.ts
+++ b/packages/wrangler/src/cfetch/index.ts
@@ -220,9 +220,11 @@ function throwFetchError(
 		maybeThrowFriendlyError(error);
 	}
 
+	const statusNote = status >= 400 ? [{ text: `Status ${status}` }] : [];
 	const error = new APIError({
 		text: `A request to the Cloudflare API (${resource}) failed.`,
 		notes: [
+			...statusNote,
 			...response.errors.map((err) => ({ text: renderError(err) })),
 			...(response.messages?.map((text) => ({ text })) ?? []),
 		],


### PR DESCRIPTION
_Describe your change..._

- Add a status line to API error notes for failed Cloudflare API requests.
- Update snapshots for match-tag, queues, R2 bucket, and pages download config errors.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s):
  - [x] Documentation not necessary because:

*An extremely polite capybara says hello.*