### PR TITLE
[vite-plugin] Publish auto-start tunnel URL

### DIFF
--- a/.changeset/bright-tunnels-smile.md
+++ b/.changeset/bright-tunnels-smile.md
@@ -2,6 +2,6 @@
 "@cloudflare/vite-plugin": minor
 ---
 
-Expose Cloudflare tunnel URLs programmatically
+Expose auto-start tunnel URLs through the default environment
 
-You can now configure `tunnel.env` to publish the primary public tunnel URL to `process.env` when the tunnel is ready, or use `tunnel.onReady` to receive structured tunnel metadata including all public URLs for named tunnels.
+Auto-started Vite plugin tunnels now publish their primary public tunnel URL to `process.env.CLOUDFLARE_TUNNEL_URL` when the tunnel is ready.

--- a/.changeset/bright-tunnels-smile.md
+++ b/.changeset/bright-tunnels-smile.md
@@ -1,0 +1,7 @@
+---
+"@cloudflare/vite-plugin": minor
+---
+
+Expose Cloudflare tunnel URLs programmatically
+
+You can now configure `tunnel.env` to publish the primary public tunnel URL to `process.env` when the tunnel is ready, or use `tunnel.onReady` to receive structured tunnel metadata including all public URLs for named tunnels.

--- a/.changeset/fuzzy-browsers-smile.md
+++ b/.changeset/fuzzy-browsers-smile.md
@@ -7,4 +7,4 @@ Pass through Vitest Browser Mode WebSocket upgrades and improve tunnel readiness
 
 Vitest Browser Mode's browser RPC WebSocket is now left for Vite/Vitest to handle instead of being forwarded to the Worker during `vite dev`, avoiding timeouts when the Worker does not return a WebSocket response.
 
-Vite plugin tunnel `env` and `onReady` are now published after any required dev server restart, and quick tunnel readiness waits for cloudflared to register an edge connection plus a short propagation window before the URL is reported.
+Auto-started Vite plugin tunnels now publish `CLOUDFLARE_TUNNEL_URL` after any required dev server restart, and quick tunnel readiness waits for cloudflared to register an edge connection plus a short propagation window before the URL is reported.

--- a/.changeset/fuzzy-browsers-smile.md
+++ b/.changeset/fuzzy-browsers-smile.md
@@ -1,0 +1,10 @@
+---
+"@cloudflare/vite-plugin": patch
+"@cloudflare/workers-utils": patch
+---
+
+Pass through Vitest Browser Mode WebSocket upgrades and improve tunnel readiness
+
+Vitest Browser Mode's browser RPC WebSocket is now left for Vite/Vitest to handle instead of being forwarded to the Worker during `vite dev`, avoiding timeouts when the Worker does not return a WebSocket response.
+
+Vite plugin tunnel `env` and `onReady` are now published after any required dev server restart, and quick tunnel readiness waits for cloudflared to register an edge connection plus a short propagation window before the URL is reported.

--- a/packages/vite-plugin-cloudflare/README.md
+++ b/packages/vite-plugin-cloudflare/README.md
@@ -29,10 +29,14 @@ Full documentation can be found [here](https://developers.cloudflare.com/workers
 
 ## Access the tunnel URL programmatically
 
-Use `tunnel: "auto"` when another tool needs a public URL and can read it from `process.env.CLOUDFLARE_TUNNEL_URL`. This starts a tunnel automatically unless `CLOUDFLARE_TUNNEL_URL` is already set:
+Use `tunnel.autoStart` when another tool needs a public URL as soon as the dev server starts. When `env` is omitted, the primary public URL is published to `process.env.CLOUDFLARE_TUNNEL_URL`:
 
 ```ts
-cloudflare({ tunnel: "auto" });
+cloudflare({
+  tunnel: {
+    autoStart: true,
+  },
+});
 ```
 
 When you need a custom environment variable name, use `tunnel.env` to write the primary public tunnel URL to `process.env` after the tunnel is ready:

--- a/packages/vite-plugin-cloudflare/README.md
+++ b/packages/vite-plugin-cloudflare/README.md
@@ -29,7 +29,7 @@ Full documentation can be found [here](https://developers.cloudflare.com/workers
 
 ## Access the tunnel URL programmatically
 
-Use `tunnel.autoStart` when another tool needs a public URL as soon as the dev server starts. When `env` is omitted, the primary public URL is published to `process.env.CLOUDFLARE_TUNNEL_URL`:
+Use `tunnel.autoStart` when another tool needs a public URL as soon as the dev server starts. The primary public URL is published to `process.env.CLOUDFLARE_TUNNEL_URL` after the tunnel is ready:
 
 ```ts
 cloudflare({
@@ -39,45 +39,28 @@ cloudflare({
 });
 ```
 
-When you need a custom environment variable name, use `tunnel.env` to write the primary public tunnel URL to `process.env` after the tunnel is ready:
+This is useful for tools that launch remote browsers, webhooks, OAuth callbacks, and device testing. For example, Vitest Browser Mode can read the public origin from `CLOUDFLARE_TUNNEL_URL`:
 
 ```ts
 cloudflare({
   tunnel: {
     autoStart: true,
-    env: "PUBLIC_TUNNEL_URL",
   },
 });
 ```
 
-This is useful for tools that launch remote browsers, webhooks, OAuth callbacks, and device testing. For example, Vitest Browser Mode can read the public origin from `VITEST_BROWSER_PUBLIC_ORIGIN`:
-
-```ts
-cloudflare({
-  tunnel: {
-    autoStart: true,
-    env: "VITEST_BROWSER_PUBLIC_ORIGIN",
-  },
-});
-```
-
-Use `tunnel.onReady` when you need structured tunnel metadata or every URL from a named tunnel:
+Named tunnels also publish the first resolved public URL to `CLOUDFLARE_TUNNEL_URL`:
 
 ```ts
 cloudflare({
   tunnel: {
     autoStart: true,
     name: "my-tunnel",
-    env: ["PUBLIC_DEV_ORIGIN", "VITEST_BROWSER_PUBLIC_ORIGIN"],
-    onReady({ url, urls, mode, kind }) {
-      console.log(`Tunnel ready for ${mode}: ${url}`);
-      console.log(`Tunnel kind: ${kind}; URLs: ${urls.join(", ")}`);
-    },
   },
 });
 ```
 
-The tunnel URL is public. For named tunnels with multiple hostnames, `env` receives `context.url`, the first URL; `onReady` receives every URL in `context.urls`. Environment variables are not removed when the tunnel closes.
+The tunnel URL is public. Environment variables are not removed when the tunnel closes.
 
 ## Use cases
 

--- a/packages/vite-plugin-cloudflare/README.md
+++ b/packages/vite-plugin-cloudflare/README.md
@@ -29,7 +29,13 @@ Full documentation can be found [here](https://developers.cloudflare.com/workers
 
 ## Access the tunnel URL programmatically
 
-When tunnel sharing is enabled, use `tunnel.env` to write the primary public tunnel URL to `process.env` after the tunnel is ready:
+Use `tunnel: "auto"` when another tool needs a public URL and can read it from `process.env.CLOUDFLARE_TUNNEL_URL`. This starts a tunnel automatically unless `CLOUDFLARE_TUNNEL_URL` is already set:
+
+```ts
+cloudflare({ tunnel: "auto" });
+```
+
+When you need a custom environment variable name, use `tunnel.env` to write the primary public tunnel URL to `process.env` after the tunnel is ready:
 
 ```ts
 cloudflare({

--- a/packages/vite-plugin-cloudflare/README.md
+++ b/packages/vite-plugin-cloudflare/README.md
@@ -27,6 +27,48 @@ Full documentation can be found [here](https://developers.cloudflare.com/workers
 - Leverages Vite's hot module replacement for consistently fast updates
 - Supports `vite preview` for previewing your build output in the Workers runtime prior to deployment
 
+## Access the tunnel URL programmatically
+
+When tunnel sharing is enabled, use `tunnel.env` to write the primary public tunnel URL to `process.env` after the tunnel is ready:
+
+```ts
+cloudflare({
+  tunnel: {
+    autoStart: true,
+    env: "PUBLIC_TUNNEL_URL",
+  },
+});
+```
+
+This is useful for tools that launch remote browsers, webhooks, OAuth callbacks, and device testing. For example, Vitest Browser Mode can read the public origin from `VITEST_BROWSER_PUBLIC_ORIGIN`:
+
+```ts
+cloudflare({
+  tunnel: {
+    autoStart: true,
+    env: "VITEST_BROWSER_PUBLIC_ORIGIN",
+  },
+});
+```
+
+Use `tunnel.onReady` when you need structured tunnel metadata or every URL from a named tunnel:
+
+```ts
+cloudflare({
+  tunnel: {
+    autoStart: true,
+    name: "my-tunnel",
+    env: ["PUBLIC_DEV_ORIGIN", "VITEST_BROWSER_PUBLIC_ORIGIN"],
+    onReady({ url, urls, mode, kind }) {
+      console.log(`Tunnel ready for ${mode}: ${url}`);
+      console.log(`Tunnel kind: ${kind}; URLs: ${urls.join(", ")}`);
+    },
+  },
+});
+```
+
+The tunnel URL is public. For named tunnels with multiple hostnames, `env` receives `context.url`, the first URL; `onReady` receives every URL in `context.urls`. Environment variables are not removed when the tunnel closes.
+
 ## Use cases
 
 - [TanStack Start](https://tanstack.com/start/)

--- a/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { removeDirSync } from "@cloudflare/workers-utils";
 import { afterEach, assert, beforeEach, describe, test, vi } from "vitest";
-import { DEFAULT_TUNNEL_URL_ENV, resolvePluginConfig } from "../plugin-config";
+import { resolvePluginConfig } from "../plugin-config";
 import type {
 	AssetsOnlyResolvedConfig,
 	PluginConfig,
@@ -40,7 +40,7 @@ describe("resolvePluginConfig - auxiliary workers", () => {
 		return configPath;
 	}
 
-	test("should publish the default tunnel env when autoStart is true", async ({
+	test("should resolve tunnel options when autoStart is true", async ({
 		expect,
 	}) => {
 		const entryConfigPath = createEntryWorkerConfig(tempDir);
@@ -53,41 +53,24 @@ describe("resolvePluginConfig - auxiliary workers", () => {
 
 		expect(result.tunnel).toMatchObject({
 			autoStart: true,
-			env: DEFAULT_TUNNEL_URL_ENV,
 		});
 	});
 
-	test("should keep a custom tunnel env when autoStart is true", async ({
-		expect,
-	}) => {
+	test("should resolve named tunnel options", async ({ expect }) => {
 		const entryConfigPath = createEntryWorkerConfig(tempDir);
 
 		const result = await resolvePluginConfig(
-			{ configPath: entryConfigPath, tunnel: { autoStart: true, env: "PUBLIC_TUNNEL_URL" } },
+			{
+				configPath: entryConfigPath,
+				tunnel: { autoStart: true, name: "my-tunnel" },
+			},
 			{ root: tempDir },
 			viteEnv
 		);
 
 		expect(result.tunnel).toMatchObject({
 			autoStart: true,
-			env: "PUBLIC_TUNNEL_URL",
-		});
-	});
-
-	test("should not publish a tunnel env when env is false", async ({
-		expect,
-	}) => {
-		const entryConfigPath = createEntryWorkerConfig(tempDir);
-
-		const result = await resolvePluginConfig(
-			{ configPath: entryConfigPath, tunnel: { autoStart: true, env: false } },
-			{ root: tempDir },
-			viteEnv
-		);
-
-		expect(result.tunnel).toMatchObject({
-			autoStart: true,
-			env: false,
+			name: "my-tunnel",
 		});
 	});
 
@@ -104,7 +87,6 @@ describe("resolvePluginConfig - auxiliary workers", () => {
 
 		expect(result.tunnel).toEqual({
 			autoStart: true,
-			env: DEFAULT_TUNNEL_URL_ENV,
 		});
 	});
 

--- a/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { removeDirSync } from "@cloudflare/workers-utils";
 import { afterEach, assert, beforeEach, describe, test, vi } from "vitest";
-import { resolvePluginConfig } from "../plugin-config";
+import { DEFAULT_TUNNEL_URL_ENV, resolvePluginConfig } from "../plugin-config";
 import type {
 	AssetsOnlyResolvedConfig,
 	PluginConfig,
@@ -16,6 +16,10 @@ describe("resolvePluginConfig - auxiliary workers", () => {
 	beforeEach(() => {
 		tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vite-plugin-test-"));
 		return () => removeDirSync(tempDir);
+	});
+
+	afterEach(() => {
+		vi.unstubAllEnvs();
 	});
 
 	const viteEnv = { mode: "development", command: "serve" as const };
@@ -35,6 +39,56 @@ describe("resolvePluginConfig - auxiliary workers", () => {
 		fs.writeFileSync(path.join(dir, "src/index.ts"), "export default {}");
 		return configPath;
 	}
+
+	test("should resolve tunnel auto to auto-start and publish the default env", async ({
+		expect,
+	}) => {
+		vi.stubEnv(DEFAULT_TUNNEL_URL_ENV, undefined);
+		const entryConfigPath = createEntryWorkerConfig(tempDir);
+
+		const result = await resolvePluginConfig(
+			{ configPath: entryConfigPath, tunnel: "auto" },
+			{ root: tempDir },
+			viteEnv
+		);
+
+		expect(result.tunnel).toMatchObject({
+			autoStart: true,
+			env: DEFAULT_TUNNEL_URL_ENV,
+		});
+	});
+
+	test("should resolve tunnel auto without auto-start when the default env is set", async ({
+		expect,
+	}) => {
+		vi.stubEnv(DEFAULT_TUNNEL_URL_ENV, "https://public.example.com");
+		const entryConfigPath = createEntryWorkerConfig(tempDir);
+
+		const result = await resolvePluginConfig(
+			{ configPath: entryConfigPath, tunnel: "auto" },
+			{ root: tempDir },
+			viteEnv
+		);
+
+		expect(result.tunnel).toMatchObject({
+			autoStart: false,
+			env: DEFAULT_TUNNEL_URL_ENV,
+		});
+	});
+
+	test("should keep boolean tunnel config backward-compatible", async ({
+		expect,
+	}) => {
+		const entryConfigPath = createEntryWorkerConfig(tempDir);
+
+		const result = await resolvePluginConfig(
+			{ configPath: entryConfigPath, tunnel: true },
+			{ root: tempDir },
+			viteEnv
+		);
+
+		expect(result.tunnel).toEqual({ autoStart: true });
+	});
 
 	test("should resolve auxiliary worker from config file", async ({
 		expect,

--- a/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/resolve-plugin-config.spec.ts
@@ -40,14 +40,13 @@ describe("resolvePluginConfig - auxiliary workers", () => {
 		return configPath;
 	}
 
-	test("should resolve tunnel auto to auto-start and publish the default env", async ({
+	test("should publish the default tunnel env when autoStart is true", async ({
 		expect,
 	}) => {
-		vi.stubEnv(DEFAULT_TUNNEL_URL_ENV, undefined);
 		const entryConfigPath = createEntryWorkerConfig(tempDir);
 
 		const result = await resolvePluginConfig(
-			{ configPath: entryConfigPath, tunnel: "auto" },
+			{ configPath: entryConfigPath, tunnel: { autoStart: true } },
 			{ root: tempDir },
 			viteEnv
 		);
@@ -58,25 +57,41 @@ describe("resolvePluginConfig - auxiliary workers", () => {
 		});
 	});
 
-	test("should resolve tunnel auto without auto-start when the default env is set", async ({
+	test("should keep a custom tunnel env when autoStart is true", async ({
 		expect,
 	}) => {
-		vi.stubEnv(DEFAULT_TUNNEL_URL_ENV, "https://public.example.com");
 		const entryConfigPath = createEntryWorkerConfig(tempDir);
 
 		const result = await resolvePluginConfig(
-			{ configPath: entryConfigPath, tunnel: "auto" },
+			{ configPath: entryConfigPath, tunnel: { autoStart: true, env: "PUBLIC_TUNNEL_URL" } },
 			{ root: tempDir },
 			viteEnv
 		);
 
 		expect(result.tunnel).toMatchObject({
-			autoStart: false,
-			env: DEFAULT_TUNNEL_URL_ENV,
+			autoStart: true,
+			env: "PUBLIC_TUNNEL_URL",
 		});
 	});
 
-	test("should keep boolean tunnel config backward-compatible", async ({
+	test("should not publish a tunnel env when env is false", async ({
+		expect,
+	}) => {
+		const entryConfigPath = createEntryWorkerConfig(tempDir);
+
+		const result = await resolvePluginConfig(
+			{ configPath: entryConfigPath, tunnel: { autoStart: true, env: false } },
+			{ root: tempDir },
+			viteEnv
+		);
+
+		expect(result.tunnel).toMatchObject({
+			autoStart: true,
+			env: false,
+		});
+	});
+
+	test("should publish the default tunnel env for boolean tunnel config", async ({
 		expect,
 	}) => {
 		const entryConfigPath = createEntryWorkerConfig(tempDir);
@@ -87,7 +102,10 @@ describe("resolvePluginConfig - auxiliary workers", () => {
 			viteEnv
 		);
 
-		expect(result.tunnel).toEqual({ autoStart: true });
+		expect(result.tunnel).toEqual({
+			autoStart: true,
+			env: DEFAULT_TUNNEL_URL_ENV,
+		});
 	});
 
 	test("should resolve auxiliary worker from config file", async ({

--- a/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
@@ -31,6 +31,7 @@ const TEST_TUNNEL_ENV_KEYS = [
 	"PUBLIC_TUNNEL_URL",
 	"PUBLIC_TUNNEL_URL_A",
 	"PUBLIC_TUNNEL_URL_B",
+	"PUBLIC_TUNNEL_URL_AFTER_RESTART",
 	"PUBLIC_TUNNEL_URL_DISABLED",
 	"NAMED_TUNNEL_URL",
 	"PREVIEW_TUNNEL_URL",
@@ -178,6 +179,40 @@ describe("tunnel plugin", () => {
 		expect(getTestEnv("PUBLIC_TUNNEL_URL")).toBe(
 			"https://example.trycloudflare.com/"
 		);
+	});
+
+	it("sets tunnel env var and calls onReady after restarting for allowed hosts", async ({
+		expect,
+	}) => {
+		const onReady = vi.fn();
+		const server = await createServer();
+		const ctx = createMockPluginContext({
+			type: "workers",
+			tunnel: {
+				autoStart: true,
+				env: "PUBLIC_TUNNEL_URL_AFTER_RESTART",
+				onReady,
+			},
+		});
+		const tunnelManager = new TunnelManager(server.config.logger);
+		const events: string[] = [];
+		const restart = vi.spyOn(server, "restart").mockImplementation(async () => {
+			events.push("restart");
+			expect(getTestEnv("PUBLIC_TUNNEL_URL_AFTER_RESTART")).toBeUndefined();
+			expect(onReady).not.toHaveBeenCalled();
+		});
+
+		onTestFinished(() => server.close());
+
+		await server.listen(0);
+		await setupDevTunnel(server, ctx, tunnelManager);
+
+		expect(restart).toHaveBeenCalledTimes(1);
+		expect(events).toEqual(["restart"]);
+		expect(getTestEnv("PUBLIC_TUNNEL_URL_AFTER_RESTART")).toBe(
+			"https://example.trycloudflare.com/"
+		);
+		expect(onReady).toHaveBeenCalledTimes(1);
 	});
 
 	it("sets multiple configured tunnel env vars", async ({ expect }) => {

--- a/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
@@ -27,6 +27,23 @@ import type * as vite from "vite";
 vi.mock("@cloudflare/workers-utils");
 vi.mock("wrangler");
 
+const TEST_TUNNEL_ENV_KEYS = [
+	"PUBLIC_TUNNEL_URL",
+	"PUBLIC_TUNNEL_URL_A",
+	"PUBLIC_TUNNEL_URL_B",
+	"PUBLIC_TUNNEL_URL_DISABLED",
+	"NAMED_TUNNEL_URL",
+	"PREVIEW_TUNNEL_URL",
+];
+
+function getTestEnv(name: string): string | undefined {
+	return process.env[name];
+}
+
+function setTestEnv(name: string, value: string): void {
+	process.env[name] = value;
+}
+
 function createMockPluginContext(options: {
 	type: "workers" | "preview";
 	tunnel?: TunnelConfig;
@@ -43,6 +60,8 @@ function createMockPluginContext(options: {
 			tunnel: {
 				autoStart: options.tunnel?.autoStart ?? false,
 				name: options.tunnel?.name,
+				env: options.tunnel?.env,
+				onReady: options.tunnel?.onReady,
 			},
 		},
 	});
@@ -77,6 +96,9 @@ describe("tunnel plugin", () => {
 	});
 
 	afterEach(() => {
+		for (const key of TEST_TUNNEL_ENV_KEYS) {
+			delete process.env[key];
+		}
 		vi.resetAllMocks();
 	});
 
@@ -135,6 +157,190 @@ describe("tunnel plugin", () => {
 			.map(([message]) => stripVTControlCharacters(message))
 			.join("\n");
 		expect(infoLog).not.toContain("Tunnel:");
+	});
+
+	it("sets configured tunnel env var when the tunnel is ready", async ({
+		expect,
+	}) => {
+		const server = await createServer();
+		const ctx = createMockPluginContext({
+			type: "workers",
+			tunnel: { autoStart: true, env: "PUBLIC_TUNNEL_URL" },
+		});
+		const tunnelManager = new TunnelManager(server.config.logger);
+		vi.spyOn(server, "restart").mockResolvedValue();
+
+		onTestFinished(() => server.close());
+
+		await server.listen(0);
+		await setupDevTunnel(server, ctx, tunnelManager);
+
+		expect(getTestEnv("PUBLIC_TUNNEL_URL")).toBe(
+			"https://example.trycloudflare.com/"
+		);
+	});
+
+	it("sets multiple configured tunnel env vars", async ({ expect }) => {
+		const server = await createServer();
+		const ctx = createMockPluginContext({
+			type: "workers",
+			tunnel: {
+				autoStart: true,
+				env: ["PUBLIC_TUNNEL_URL_A", "PUBLIC_TUNNEL_URL_B"],
+			},
+		});
+		const tunnelManager = new TunnelManager(server.config.logger);
+		vi.spyOn(server, "restart").mockResolvedValue();
+
+		onTestFinished(() => server.close());
+
+		await server.listen(0);
+		await setupDevTunnel(server, ctx, tunnelManager);
+
+		expect(getTestEnv("PUBLIC_TUNNEL_URL_A")).toBe(
+			"https://example.trycloudflare.com/"
+		);
+		expect(getTestEnv("PUBLIC_TUNNEL_URL_B")).toBe(
+			"https://example.trycloudflare.com/"
+		);
+	});
+
+	it("does not change env vars when tunnel env is false", async ({
+		expect,
+	}) => {
+		setTestEnv("PUBLIC_TUNNEL_URL_DISABLED", "existing");
+		const server = await createServer();
+		const ctx = createMockPluginContext({
+			type: "workers",
+			tunnel: { autoStart: true, env: false },
+		});
+		const tunnelManager = new TunnelManager(server.config.logger);
+		vi.spyOn(server, "restart").mockResolvedValue();
+
+		onTestFinished(() => server.close());
+
+		await server.listen(0);
+		await setupDevTunnel(server, ctx, tunnelManager);
+
+		expect(getTestEnv("PUBLIC_TUNNEL_URL_DISABLED")).toBe("existing");
+	});
+
+	it("calls onReady with quick tunnel context", async ({ expect }) => {
+		const onReady = vi.fn();
+		const server = await createServer();
+		const ctx = createMockPluginContext({
+			type: "workers",
+			tunnel: { autoStart: true, onReady },
+		});
+		const tunnelManager = new TunnelManager(server.config.logger);
+		vi.spyOn(server, "restart").mockResolvedValue();
+
+		onTestFinished(() => server.close());
+
+		await server.listen(0);
+		await setupDevTunnel(server, ctx, tunnelManager);
+
+		expect(onReady).toHaveBeenCalledTimes(1);
+		expect(onReady).toHaveBeenCalledWith({
+			urls: ["https://example.trycloudflare.com/"],
+			url: "https://example.trycloudflare.com/",
+			hostnames: ["example.trycloudflare.com"],
+			hostname: "example.trycloudflare.com",
+			origin: server.resolvedUrls?.local?.[0] ?? "",
+			mode: "dev",
+			kind: "quick",
+			name: undefined,
+		});
+	});
+
+	it("publishes first named tunnel URL and calls onReady with all URLs", async ({
+		expect,
+	}) => {
+		vi.mocked(wrangler.unstable_resolveNamedTunnel).mockResolvedValue({
+			hostnames: ["one.example.com", "two.example.com"],
+			token: "TOKEN",
+		});
+		vi.mocked(startTunnel).mockReturnValue({
+			ready: vi.fn().mockResolvedValue({
+				mode: "named",
+			}),
+			isOpen: vi.fn(() => true),
+			extendExpiry: vi.fn(),
+			dispose: vi.fn(),
+		});
+		const onReady = vi.fn();
+		const server = await createServer();
+		const ctx = createMockPluginContext({
+			type: "workers",
+			tunnel: {
+				autoStart: true,
+				name: "my-tunnel",
+				env: "NAMED_TUNNEL_URL",
+				onReady,
+			},
+		});
+		const tunnelManager = new TunnelManager(server.config.logger);
+		vi.spyOn(server, "restart").mockResolvedValue();
+
+		onTestFinished(() => server.close());
+
+		await server.listen(0);
+		await setupDevTunnel(server, ctx, tunnelManager);
+
+		expect(getTestEnv("NAMED_TUNNEL_URL")).toBe("https://one.example.com");
+		expect(onReady).toHaveBeenCalledTimes(1);
+		expect(onReady).toHaveBeenCalledWith({
+			urls: ["https://one.example.com", "https://two.example.com"],
+			url: "https://one.example.com",
+			hostnames: ["one.example.com", "two.example.com"],
+			hostname: "one.example.com",
+			origin: server.resolvedUrls?.local?.[0] ?? "",
+			mode: "dev",
+			kind: "named",
+			name: "my-tunnel",
+		});
+	});
+
+	it("publishes tunnel env and calls onReady in preview mode", async ({
+		expect,
+	}) => {
+		const onReady = vi.fn();
+		const previewServer = await preview({
+			preview: {
+				allowedHosts: [QUICK_TUNNEL_ALLOWED_HOST],
+			},
+		});
+		const tunnelManager = new TunnelManager(
+			previewServer.config.logger as vite.Logger
+		);
+		const ctx = createMockPluginContext({
+			type: "preview",
+			tunnel: {
+				autoStart: true,
+				env: "PREVIEW_TUNNEL_URL",
+				onReady,
+			},
+		});
+
+		onTestFinished(() => previewServer.close());
+
+		await setupPreviewTunnel(previewServer, ctx, tunnelManager);
+
+		const startTunnelCall = vi.mocked(startTunnel).mock.calls[0]?.[0];
+		expect(getTestEnv("PREVIEW_TUNNEL_URL")).toBe(
+			"https://example.trycloudflare.com/"
+		);
+		expect(onReady).toHaveBeenCalledTimes(1);
+		expect(onReady).toHaveBeenCalledWith({
+			urls: ["https://example.trycloudflare.com/"],
+			url: "https://example.trycloudflare.com/",
+			hostnames: ["example.trycloudflare.com"],
+			hostname: "example.trycloudflare.com",
+			origin: startTunnelCall?.origin.toString(),
+			mode: "preview",
+			kind: "quick",
+			name: undefined,
+		});
 	});
 
 	it("reuses the same tunnel when the origin is unchanged", async ({
@@ -253,6 +459,67 @@ describe("tunnel plugin", () => {
 		});
 	});
 
+	it("does not call onReady when a tunnel start result is ignored", async ({
+		expect,
+	}) => {
+		const firstReady = createDeferred<{
+			mode: "quick";
+			publicUrl: URL;
+		}>();
+		vi.mocked(startTunnel)
+			.mockReturnValueOnce({
+				ready: vi.fn().mockReturnValue(firstReady.promise),
+				isOpen: vi.fn(() => true),
+				extendExpiry: vi.fn(),
+				dispose: vi.fn(),
+			})
+			.mockReturnValueOnce({
+				ready: vi.fn().mockResolvedValue({
+					mode: "quick",
+					publicUrl: new URL("https://bar.trycloudflare.com"),
+				}),
+				isOpen: vi.fn(() => true),
+				extendExpiry: vi.fn(),
+				dispose: vi.fn(),
+			});
+
+		const onReady = vi.fn();
+		const ctx = createMockPluginContext({
+			type: "workers",
+			tunnel: { autoStart: true, onReady },
+		});
+		const server1 = await createServer();
+		const server2 = await createServer();
+		const tunnelManager = new TunnelManager(server1.config.logger);
+		vi.spyOn(server1, "restart").mockResolvedValue();
+		vi.spyOn(server2, "restart").mockResolvedValue();
+
+		onTestFinished(() => server1.close());
+		onTestFinished(() => server2.close());
+
+		await server1.listen(0);
+		await server2.listen(0);
+
+		const firstSetup = setupDevTunnel(server1, ctx, tunnelManager);
+		await vi.waitFor(() => {
+			expect(startTunnel).toHaveBeenCalledTimes(1);
+		});
+
+		await setupDevTunnel(server2, ctx, tunnelManager);
+		firstReady.resolve({
+			mode: "quick",
+			publicUrl: new URL("https://foo.trycloudflare.com"),
+		});
+		await firstSetup;
+
+		expect(onReady).toHaveBeenCalledTimes(1);
+		expect(onReady).toHaveBeenCalledWith(
+			expect.objectContaining({
+				url: "https://bar.trycloudflare.com/",
+			})
+		);
+	});
+
 	it("rejects tunnel sharing in middleware mode", async ({ expect }) => {
 		const server = { httpServer: null } as unknown as vite.ViteDevServer;
 
@@ -340,6 +607,28 @@ describe("tunnel plugin", () => {
 		await plugin.configureServer(server);
 
 		await expect(() => server.listen(0)).rejects.toBe(tunnelError);
+		expect(close).toHaveBeenCalledTimes(1);
+		expect(server.httpServer?.listening).toBe(false);
+	});
+
+	it("rejects server.listen when onReady rejects", async ({ expect }) => {
+		const onReadyError = new Error("onReady failed");
+		const onReady = vi.fn().mockRejectedValue(onReadyError);
+		const server = await createServer();
+		const ctx = createMockPluginContext({
+			type: "workers",
+			tunnel: { autoStart: true, onReady },
+		});
+
+		const plugin = tunnelPlugin(ctx);
+		const close = vi.spyOn(server, "close");
+
+		onTestFinished(() => server.close());
+
+		// @ts-expect-error The tunnel plugin accepts a server instance directly without relying on `this`
+		await plugin.configureServer(server);
+
+		await expect(() => server.listen(0)).rejects.toBe(onReadyError);
 		expect(close).toHaveBeenCalledTimes(1);
 		expect(server.httpServer?.listening).toBe(false);
 	});

--- a/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/tunnel.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "vitest";
 import * as wrangler from "wrangler";
 import { PluginContext } from "../context";
+import { DEFAULT_TUNNEL_URL_ENV } from "../plugin-config";
 import {
 	QUICK_TUNNEL_ALLOWED_HOST,
 	resolveDevTunnelOrigin,
@@ -27,22 +28,10 @@ import type * as vite from "vite";
 vi.mock("@cloudflare/workers-utils");
 vi.mock("wrangler");
 
-const TEST_TUNNEL_ENV_KEYS = [
-	"PUBLIC_TUNNEL_URL",
-	"PUBLIC_TUNNEL_URL_A",
-	"PUBLIC_TUNNEL_URL_B",
-	"PUBLIC_TUNNEL_URL_AFTER_RESTART",
-	"PUBLIC_TUNNEL_URL_DISABLED",
-	"NAMED_TUNNEL_URL",
-	"PREVIEW_TUNNEL_URL",
-];
+const TEST_TUNNEL_ENV_KEYS = [DEFAULT_TUNNEL_URL_ENV];
 
 function getTestEnv(name: string): string | undefined {
 	return process.env[name];
-}
-
-function setTestEnv(name: string, value: string): void {
-	process.env[name] = value;
 }
 
 function createMockPluginContext(options: {
@@ -61,8 +50,6 @@ function createMockPluginContext(options: {
 			tunnel: {
 				autoStart: options.tunnel?.autoStart ?? false,
 				name: options.tunnel?.name,
-				env: options.tunnel?.env,
-				onReady: options.tunnel?.onReady,
 			},
 		},
 	});
@@ -160,13 +147,13 @@ describe("tunnel plugin", () => {
 		expect(infoLog).not.toContain("Tunnel:");
 	});
 
-	it("sets configured tunnel env var when the tunnel is ready", async ({
+	it("sets default tunnel env var when an auto-start tunnel is ready", async ({
 		expect,
 	}) => {
 		const server = await createServer();
 		const ctx = createMockPluginContext({
 			type: "workers",
-			tunnel: { autoStart: true, env: "PUBLIC_TUNNEL_URL" },
+			tunnel: { autoStart: true },
 		});
 		const tunnelManager = new TunnelManager(server.config.logger);
 		vi.spyOn(server, "restart").mockResolvedValue();
@@ -176,30 +163,24 @@ describe("tunnel plugin", () => {
 		await server.listen(0);
 		await setupDevTunnel(server, ctx, tunnelManager);
 
-		expect(getTestEnv("PUBLIC_TUNNEL_URL")).toBe(
+		expect(getTestEnv(DEFAULT_TUNNEL_URL_ENV)).toBe(
 			"https://example.trycloudflare.com/"
 		);
 	});
 
-	it("sets tunnel env var and calls onReady after restarting for allowed hosts", async ({
+	it("sets default tunnel env var after restarting for allowed hosts", async ({
 		expect,
 	}) => {
-		const onReady = vi.fn();
 		const server = await createServer();
 		const ctx = createMockPluginContext({
 			type: "workers",
-			tunnel: {
-				autoStart: true,
-				env: "PUBLIC_TUNNEL_URL_AFTER_RESTART",
-				onReady,
-			},
+			tunnel: { autoStart: true },
 		});
 		const tunnelManager = new TunnelManager(server.config.logger);
 		const events: string[] = [];
 		const restart = vi.spyOn(server, "restart").mockImplementation(async () => {
 			events.push("restart");
-			expect(getTestEnv("PUBLIC_TUNNEL_URL_AFTER_RESTART")).toBeUndefined();
-			expect(onReady).not.toHaveBeenCalled();
+			expect(getTestEnv(DEFAULT_TUNNEL_URL_ENV)).toBeUndefined();
 		});
 
 		onTestFinished(() => server.close());
@@ -209,45 +190,18 @@ describe("tunnel plugin", () => {
 
 		expect(restart).toHaveBeenCalledTimes(1);
 		expect(events).toEqual(["restart"]);
-		expect(getTestEnv("PUBLIC_TUNNEL_URL_AFTER_RESTART")).toBe(
-			"https://example.trycloudflare.com/"
-		);
-		expect(onReady).toHaveBeenCalledTimes(1);
-	});
-
-	it("sets multiple configured tunnel env vars", async ({ expect }) => {
-		const server = await createServer();
-		const ctx = createMockPluginContext({
-			type: "workers",
-			tunnel: {
-				autoStart: true,
-				env: ["PUBLIC_TUNNEL_URL_A", "PUBLIC_TUNNEL_URL_B"],
-			},
-		});
-		const tunnelManager = new TunnelManager(server.config.logger);
-		vi.spyOn(server, "restart").mockResolvedValue();
-
-		onTestFinished(() => server.close());
-
-		await server.listen(0);
-		await setupDevTunnel(server, ctx, tunnelManager);
-
-		expect(getTestEnv("PUBLIC_TUNNEL_URL_A")).toBe(
-			"https://example.trycloudflare.com/"
-		);
-		expect(getTestEnv("PUBLIC_TUNNEL_URL_B")).toBe(
+		expect(getTestEnv(DEFAULT_TUNNEL_URL_ENV)).toBe(
 			"https://example.trycloudflare.com/"
 		);
 	});
 
-	it("does not change env vars when tunnel env is false", async ({
+	it("does not set default tunnel env var for manually started tunnels", async ({
 		expect,
 	}) => {
-		setTestEnv("PUBLIC_TUNNEL_URL_DISABLED", "existing");
 		const server = await createServer();
 		const ctx = createMockPluginContext({
 			type: "workers",
-			tunnel: { autoStart: true, env: false },
+			tunnel: { autoStart: false },
 		});
 		const tunnelManager = new TunnelManager(server.config.logger);
 		vi.spyOn(server, "restart").mockResolvedValue();
@@ -257,38 +211,10 @@ describe("tunnel plugin", () => {
 		await server.listen(0);
 		await setupDevTunnel(server, ctx, tunnelManager);
 
-		expect(getTestEnv("PUBLIC_TUNNEL_URL_DISABLED")).toBe("existing");
+		expect(getTestEnv(DEFAULT_TUNNEL_URL_ENV)).toBeUndefined();
 	});
 
-	it("calls onReady with quick tunnel context", async ({ expect }) => {
-		const onReady = vi.fn();
-		const server = await createServer();
-		const ctx = createMockPluginContext({
-			type: "workers",
-			tunnel: { autoStart: true, onReady },
-		});
-		const tunnelManager = new TunnelManager(server.config.logger);
-		vi.spyOn(server, "restart").mockResolvedValue();
-
-		onTestFinished(() => server.close());
-
-		await server.listen(0);
-		await setupDevTunnel(server, ctx, tunnelManager);
-
-		expect(onReady).toHaveBeenCalledTimes(1);
-		expect(onReady).toHaveBeenCalledWith({
-			urls: ["https://example.trycloudflare.com/"],
-			url: "https://example.trycloudflare.com/",
-			hostnames: ["example.trycloudflare.com"],
-			hostname: "example.trycloudflare.com",
-			origin: server.resolvedUrls?.local?.[0] ?? "",
-			mode: "dev",
-			kind: "quick",
-			name: undefined,
-		});
-	});
-
-	it("publishes first named tunnel URL and calls onReady with all URLs", async ({
+	it("publishes first named tunnel URL to the default env var", async ({
 		expect,
 	}) => {
 		vi.mocked(wrangler.unstable_resolveNamedTunnel).mockResolvedValue({
@@ -303,15 +229,12 @@ describe("tunnel plugin", () => {
 			extendExpiry: vi.fn(),
 			dispose: vi.fn(),
 		});
-		const onReady = vi.fn();
 		const server = await createServer();
 		const ctx = createMockPluginContext({
 			type: "workers",
 			tunnel: {
 				autoStart: true,
 				name: "my-tunnel",
-				env: "NAMED_TUNNEL_URL",
-				onReady,
 			},
 		});
 		const tunnelManager = new TunnelManager(server.config.logger);
@@ -322,24 +245,10 @@ describe("tunnel plugin", () => {
 		await server.listen(0);
 		await setupDevTunnel(server, ctx, tunnelManager);
 
-		expect(getTestEnv("NAMED_TUNNEL_URL")).toBe("https://one.example.com");
-		expect(onReady).toHaveBeenCalledTimes(1);
-		expect(onReady).toHaveBeenCalledWith({
-			urls: ["https://one.example.com", "https://two.example.com"],
-			url: "https://one.example.com",
-			hostnames: ["one.example.com", "two.example.com"],
-			hostname: "one.example.com",
-			origin: server.resolvedUrls?.local?.[0] ?? "",
-			mode: "dev",
-			kind: "named",
-			name: "my-tunnel",
-		});
+		expect(getTestEnv(DEFAULT_TUNNEL_URL_ENV)).toBe("https://one.example.com");
 	});
 
-	it("publishes tunnel env and calls onReady in preview mode", async ({
-		expect,
-	}) => {
-		const onReady = vi.fn();
+	it("publishes default tunnel env in preview mode", async ({ expect }) => {
 		const previewServer = await preview({
 			preview: {
 				allowedHosts: [QUICK_TUNNEL_ALLOWED_HOST],
@@ -350,11 +259,7 @@ describe("tunnel plugin", () => {
 		);
 		const ctx = createMockPluginContext({
 			type: "preview",
-			tunnel: {
-				autoStart: true,
-				env: "PREVIEW_TUNNEL_URL",
-				onReady,
-			},
+			tunnel: { autoStart: true },
 		});
 
 		onTestFinished(() => previewServer.close());
@@ -362,20 +267,10 @@ describe("tunnel plugin", () => {
 		await setupPreviewTunnel(previewServer, ctx, tunnelManager);
 
 		const startTunnelCall = vi.mocked(startTunnel).mock.calls[0]?.[0];
-		expect(getTestEnv("PREVIEW_TUNNEL_URL")).toBe(
+		expect(getTestEnv(DEFAULT_TUNNEL_URL_ENV)).toBe(
 			"https://example.trycloudflare.com/"
 		);
-		expect(onReady).toHaveBeenCalledTimes(1);
-		expect(onReady).toHaveBeenCalledWith({
-			urls: ["https://example.trycloudflare.com/"],
-			url: "https://example.trycloudflare.com/",
-			hostnames: ["example.trycloudflare.com"],
-			hostname: "example.trycloudflare.com",
-			origin: startTunnelCall?.origin.toString(),
-			mode: "preview",
-			kind: "quick",
-			name: undefined,
-		});
+		expect(startTunnelCall?.origin.toString()).toBeDefined();
 	});
 
 	it("reuses the same tunnel when the origin is unchanged", async ({
@@ -494,9 +389,7 @@ describe("tunnel plugin", () => {
 		});
 	});
 
-	it("does not call onReady when a tunnel start result is ignored", async ({
-		expect,
-	}) => {
+	it("does not publish ignored tunnel start results", async ({ expect }) => {
 		const firstReady = createDeferred<{
 			mode: "quick";
 			publicUrl: URL;
@@ -518,10 +411,9 @@ describe("tunnel plugin", () => {
 				dispose: vi.fn(),
 			});
 
-		const onReady = vi.fn();
 		const ctx = createMockPluginContext({
 			type: "workers",
-			tunnel: { autoStart: true, onReady },
+			tunnel: { autoStart: true },
 		});
 		const server1 = await createServer();
 		const server2 = await createServer();
@@ -547,11 +439,8 @@ describe("tunnel plugin", () => {
 		});
 		await firstSetup;
 
-		expect(onReady).toHaveBeenCalledTimes(1);
-		expect(onReady).toHaveBeenCalledWith(
-			expect.objectContaining({
-				url: "https://bar.trycloudflare.com/",
-			})
+		expect(getTestEnv(DEFAULT_TUNNEL_URL_ENV)).toBe(
+			"https://bar.trycloudflare.com/"
 		);
 	});
 
@@ -642,28 +531,6 @@ describe("tunnel plugin", () => {
 		await plugin.configureServer(server);
 
 		await expect(() => server.listen(0)).rejects.toBe(tunnelError);
-		expect(close).toHaveBeenCalledTimes(1);
-		expect(server.httpServer?.listening).toBe(false);
-	});
-
-	it("rejects server.listen when onReady rejects", async ({ expect }) => {
-		const onReadyError = new Error("onReady failed");
-		const onReady = vi.fn().mockRejectedValue(onReadyError);
-		const server = await createServer();
-		const ctx = createMockPluginContext({
-			type: "workers",
-			tunnel: { autoStart: true, onReady },
-		});
-
-		const plugin = tunnelPlugin(ctx);
-		const close = vi.spyOn(server, "close");
-
-		onTestFinished(() => server.close());
-
-		// @ts-expect-error The tunnel plugin accepts a server instance directly without relying on `this`
-		await plugin.configureServer(server);
-
-		await expect(() => server.listen(0)).rejects.toBe(onReadyError);
 		expect(close).toHaveBeenCalledTimes(1);
 		expect(server.httpServer?.listening).toBe(false);
 	});

--- a/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
+++ b/packages/vite-plugin-cloudflare/src/__tests__/websockets.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "vitest";
 import { handleWebSocket } from "../websockets";
 import type { AddressInfo } from "node:net";
+import type { Duplex } from "node:stream";
 
 describe("handleWebSocket", () => {
 	let httpServer: http.Server;
@@ -36,6 +37,65 @@ describe("handleWebSocket", () => {
 		handleWebSocket(httpServer, miniflare, entryWorkerName);
 		await new Promise<void>((r) => httpServer.listen(0, "127.0.0.1", r));
 		port = (httpServer.address() as AddressInfo).port;
+	}
+
+	async function connectUpgradeSocket(options?: {
+		path?: string;
+		headers?: Record<string, string>;
+	}) {
+		const socket = net.connect(port, "127.0.0.1");
+		socket.on("error", () => {});
+		await new Promise<void>((r) => socket.on("connect", r));
+
+		const headers = {
+			Host: `127.0.0.1:${port}`,
+			...options?.headers,
+		};
+		const headerLines = Object.entries(headers)
+			.map(([key, value]) => `${key}: ${value}`)
+			.join("\r\n");
+
+		socket.write(
+			`GET ${options?.path ?? "/"} HTTP/1.1\r\n` +
+				`${headerLines}\r\n` +
+				"Upgrade: websocket\r\n" +
+				"Connection: Upgrade\r\n" +
+				"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n" +
+				"Sec-WebSocket-Version: 13\r\n\r\n"
+		);
+
+		return socket;
+	}
+
+	async function expectUpgradePassesThrough(
+		expect: ExpectStatic,
+		options?: {
+			path?: string;
+			headers?: Record<string, string>;
+		}
+	) {
+		const mockedDispatchFetch = vi.spyOn(miniflare, "dispatchFetch");
+		let serverSocket: Duplex | undefined;
+		let serverSocketDestroyed = true;
+		const passThroughSeen = new Promise<void>((resolve) => {
+			httpServer.once("upgrade", (_request, upgradedSocket) => {
+				serverSocket = upgradedSocket;
+				setImmediate(() => {
+					serverSocketDestroyed = upgradedSocket.destroyed;
+					resolve();
+				});
+			});
+		});
+
+		const socket = await connectUpgradeSocket(options);
+		await passThroughSeen;
+
+		expect(mockedDispatchFetch).not.toHaveBeenCalled();
+		expect(serverSocketDestroyed).toBe(false);
+		expect(socket.destroyed).toBe(false);
+
+		serverSocket?.destroy();
+		socket.destroy();
 	}
 
 	afterEach(async () => {
@@ -74,6 +134,62 @@ describe("handleWebSocket", () => {
 		// Verify server did not crash and is still responsive
 		const response = await fetch(`http://127.0.0.1:${port}`);
 		expect(response.ok).toBe(true);
+	});
+
+	test("passes through Vite HMR requests outside sandbox origins", async ({
+		expect,
+	}) => {
+		await listen();
+
+		await expectUpgradePassesThrough(expect, {
+			headers: {
+				"Sec-WebSocket-Protocol": "vite-hmr",
+			},
+		});
+	});
+
+	test("passes through Vitest Browser RPC requests by subprotocol", async ({
+		expect,
+	}) => {
+		await listen();
+
+		await expectUpgradePassesThrough(expect, {
+			headers: {
+				"Sec-WebSocket-Protocol": "vitest-browser-rpc",
+			},
+		});
+	});
+
+	test("passes through Vitest Browser RPC requests by pathname", async ({
+		expect,
+	}) => {
+		await listen();
+
+		await expectUpgradePassesThrough(expect, {
+			path: "/__vitest_browser_api__",
+		});
+	});
+
+	test("dispatches ordinary Worker WebSocket upgrades", async ({ expect }) => {
+		await listen();
+
+		const deferred = new DeferredPromise<Response>();
+		const mockedDispatchFetch = vi
+			.spyOn(miniflare, "dispatchFetch")
+			.mockReturnValue(deferred);
+
+		const socket = await connectUpgradeSocket({ path: "/worker-websocket" });
+
+		await vi.waitFor(() => expect(miniflare.dispatchFetch).toHaveBeenCalled());
+
+		// Resolve the mock so miniflare.dispose() doesn't hang in afterEach
+		deferred.resolve(new Response(null));
+
+		socket.destroy();
+
+		assert(mockedDispatchFetch.mock.lastCall);
+		const [url] = mockedDispatchFetch.mock.lastCall;
+		expect(`${url}`).toBe(`http://127.0.0.1:${port}/worker-websocket`);
 	});
 
 	test("forwards sandbox requests", async ({ expect }) => {

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -48,7 +48,13 @@ export function getLocalWorkerdCompatibilityDate(_options?: {
 	return { date: DEFAULT_COMPAT_DATE, source: "workerd" };
 }
 
-export type { PluginConfig } from "./plugin-config";
+export type {
+	PluginConfig,
+	TunnelConfig,
+	TunnelKind,
+	TunnelMode,
+	TunnelReadyContext,
+} from "./plugin-config";
 export type { WorkerConfig } from "./workers-configs";
 
 const sharedContext: SharedContext = {

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -55,6 +55,7 @@ export type {
 	TunnelMode,
 	TunnelReadyContext,
 } from "./plugin-config";
+export { DEFAULT_TUNNEL_URL_ENV } from "./plugin-config";
 export type { WorkerConfig } from "./workers-configs";
 
 const sharedContext: SharedContext = {

--- a/packages/vite-plugin-cloudflare/src/index.ts
+++ b/packages/vite-plugin-cloudflare/src/index.ts
@@ -48,14 +48,7 @@ export function getLocalWorkerdCompatibilityDate(_options?: {
 	return { date: DEFAULT_COMPAT_DATE, source: "workerd" };
 }
 
-export type {
-	PluginConfig,
-	TunnelConfig,
-	TunnelKind,
-	TunnelMode,
-	TunnelReadyContext,
-} from "./plugin-config";
-export { DEFAULT_TUNNEL_URL_ENV } from "./plugin-config";
+export type { PluginConfig, TunnelConfig } from "./plugin-config";
 export type { WorkerConfig } from "./workers-configs";
 
 const sharedContext: SharedContext = {

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -179,23 +179,20 @@ function normalizeNewConfig(
 }
 
 function resolveTunnelConfig(tunnel: PluginConfig["tunnel"]): TunnelConfig {
-	if (tunnel === "auto") {
-		return {
-			autoStart: !process.env[DEFAULT_TUNNEL_URL_ENV],
-			env: DEFAULT_TUNNEL_URL_ENV,
-		};
+	const resolved: TunnelConfig = typeof tunnel === "boolean"
+		? { autoStart: tunnel }
+		: {
+				autoStart: tunnel?.autoStart ?? false,
+				name: tunnel?.name,
+				env: tunnel?.env,
+				onReady: tunnel?.onReady,
+			};
+
+	if (resolved.autoStart && resolved.env === undefined) {
+		resolved.env = DEFAULT_TUNNEL_URL_ENV;
 	}
 
-	if (typeof tunnel === "boolean") {
-		return { autoStart: tunnel };
-	}
-
-	return {
-		autoStart: tunnel?.autoStart ?? false,
-		name: tunnel?.name,
-		env: tunnel?.env,
-		onReady: tunnel?.onReady,
-	};
+	return resolved;
 }
 
 type FilteredEntryWorkerConfig = Omit<
@@ -219,7 +216,7 @@ export interface PluginConfig extends EntryWorkerConfig {
 	persistState?: PersistState;
 	inspectorPort?: number | false;
 	remoteBindings?: boolean;
-	tunnel?: boolean | "auto" | TunnelConfig;
+	tunnel?: boolean | TunnelConfig;
 	experimental?: Experimental;
 }
 

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -40,6 +40,7 @@ import type { Unstable_Config } from "wrangler";
 export type PersistState = boolean | { path: string };
 export type TunnelMode = "dev" | "preview";
 export type TunnelKind = "quick" | "named";
+export const DEFAULT_TUNNEL_URL_ENV = "CLOUDFLARE_TUNNEL_URL";
 export interface TunnelReadyContext {
 	urls: string[];
 	url: string;
@@ -177,6 +178,26 @@ function normalizeNewConfig(
 	};
 }
 
+function resolveTunnelConfig(tunnel: PluginConfig["tunnel"]): TunnelConfig {
+	if (tunnel === "auto") {
+		return {
+			autoStart: !process.env[DEFAULT_TUNNEL_URL_ENV],
+			env: DEFAULT_TUNNEL_URL_ENV,
+		};
+	}
+
+	if (typeof tunnel === "boolean") {
+		return { autoStart: tunnel };
+	}
+
+	return {
+		autoStart: tunnel?.autoStart ?? false,
+		name: tunnel?.name,
+		env: tunnel?.env,
+		onReady: tunnel?.onReady,
+	};
+}
+
 type FilteredEntryWorkerConfig = Omit<
 	ResolvedAssetsOnlyConfig,
 	"topLevelName" | "name"
@@ -198,7 +219,7 @@ export interface PluginConfig extends EntryWorkerConfig {
 	persistState?: PersistState;
 	inspectorPort?: number | false;
 	remoteBindings?: boolean;
-	tunnel?: boolean | TunnelConfig;
+	tunnel?: boolean | "auto" | TunnelConfig;
 	experimental?: Experimental;
 }
 
@@ -423,15 +444,7 @@ export async function resolvePluginConfig(
 	const shared = {
 		persistState: pluginConfig.persistState ?? true,
 		inspectorPort: pluginConfig.inspectorPort,
-		tunnel:
-			typeof pluginConfig.tunnel === "boolean"
-				? { autoStart: pluginConfig.tunnel }
-				: {
-						autoStart: pluginConfig.tunnel?.autoStart ?? false,
-						name: pluginConfig.tunnel?.name,
-						env: pluginConfig.tunnel?.env,
-						onReady: pluginConfig.tunnel?.onReady,
-					},
+		tunnel: resolveTunnelConfig(pluginConfig.tunnel),
 		experimental: {
 			headersAndRedirectsDevModeSupport:
 				pluginConfig.experimental?.headersAndRedirectsDevModeSupport,

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -38,24 +38,10 @@ import type { RawConfig } from "@cloudflare/workers-utils";
 import type { Unstable_Config } from "wrangler";
 
 export type PersistState = boolean | { path: string };
-export type TunnelMode = "dev" | "preview";
-export type TunnelKind = "quick" | "named";
 export const DEFAULT_TUNNEL_URL_ENV = "CLOUDFLARE_TUNNEL_URL";
-export interface TunnelReadyContext {
-	urls: string[];
-	url: string;
-	hostnames: string[];
-	hostname: string;
-	origin: string;
-	mode: TunnelMode;
-	kind: TunnelKind;
-	name?: string;
-}
 export type TunnelConfig = {
 	autoStart?: boolean;
 	name?: string;
-	env?: string | string[] | false;
-	onReady?: (context: TunnelReadyContext) => void | Promise<void>;
 };
 
 interface BaseWorkerConfig {
@@ -179,20 +165,12 @@ function normalizeNewConfig(
 }
 
 function resolveTunnelConfig(tunnel: PluginConfig["tunnel"]): TunnelConfig {
-	const resolved: TunnelConfig = typeof tunnel === "boolean"
+	return typeof tunnel === "boolean"
 		? { autoStart: tunnel }
 		: {
 				autoStart: tunnel?.autoStart ?? false,
 				name: tunnel?.name,
-				env: tunnel?.env,
-				onReady: tunnel?.onReady,
 			};
-
-	if (resolved.autoStart && resolved.env === undefined) {
-		resolved.env = DEFAULT_TUNNEL_URL_ENV;
-	}
-
-	return resolved;
 }
 
 type FilteredEntryWorkerConfig = Omit<

--- a/packages/vite-plugin-cloudflare/src/plugin-config.ts
+++ b/packages/vite-plugin-cloudflare/src/plugin-config.ts
@@ -38,9 +38,23 @@ import type { RawConfig } from "@cloudflare/workers-utils";
 import type { Unstable_Config } from "wrangler";
 
 export type PersistState = boolean | { path: string };
+export type TunnelMode = "dev" | "preview";
+export type TunnelKind = "quick" | "named";
+export interface TunnelReadyContext {
+	urls: string[];
+	url: string;
+	hostnames: string[];
+	hostname: string;
+	origin: string;
+	mode: TunnelMode;
+	kind: TunnelKind;
+	name?: string;
+}
 export type TunnelConfig = {
 	autoStart?: boolean;
 	name?: string;
+	env?: string | string[] | false;
+	onReady?: (context: TunnelReadyContext) => void | Promise<void>;
 };
 
 interface BaseWorkerConfig {
@@ -415,6 +429,8 @@ export async function resolvePluginConfig(
 				: {
 						autoStart: pluginConfig.tunnel?.autoStart ?? false,
 						name: pluginConfig.tunnel?.name,
+						env: pluginConfig.tunnel?.env,
+						onReady: pluginConfig.tunnel?.onReady,
 					},
 		experimental: {
 			headersAndRedirectsDevModeSupport:

--- a/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
@@ -5,14 +5,9 @@ import colors from "picocolors";
 import encodeQR from "qr";
 import * as wrangler from "wrangler";
 import { assertIsNotPreview, assertIsPreview } from "../context";
+import { DEFAULT_TUNNEL_URL_ENV } from "../plugin-config";
 import { debuglog, createPlugin } from "../utils";
 import type { PluginContext } from "../context";
-import type {
-	TunnelConfig,
-	TunnelKind,
-	TunnelMode,
-	TunnelReadyContext,
-} from "../plugin-config";
 import type { Tunnel } from "@cloudflare/workers-utils";
 import type * as vite from "vite";
 
@@ -76,7 +71,6 @@ export const QUICK_TUNNEL_ALLOWED_HOST = ".trycloudflare.com";
 
 interface TunnelStartResult {
 	publicUrls: string[];
-	kind: TunnelKind;
 }
 
 export class TunnelManager {
@@ -234,14 +228,14 @@ export class TunnelManager {
 
 			if (result.mode === "named") {
 				const publicUrls = this.#publicUrls;
-				return publicUrls ? { publicUrls, kind: "named" } : null;
+				return publicUrls ? { publicUrls } : null;
 			}
 
 			const { publicUrl } = result;
 
 			debuglog("Tunnel is ready with public URL:", publicUrl);
 			this.#publicUrls = [publicUrl.toString()];
-			return { publicUrls: this.#publicUrls, kind: "quick" };
+			return { publicUrls: this.#publicUrls };
 		} catch (error) {
 			if (this.#tunnel !== tunnel) {
 				return null;
@@ -431,65 +425,13 @@ export async function resolvePreviewTunnelOrigin(server: vite.PreviewServer) {
 	);
 }
 
-function createTunnelReadyContext(options: {
-	publicUrls: string[];
-	origin: string;
-	mode: TunnelMode;
-	kind: TunnelKind;
-	name?: string;
-}): TunnelReadyContext {
-	const urls = [...options.publicUrls];
-	const url = urls[0];
+function publishDefaultTunnelUrl(publicUrls: string[]): void {
+	const url = publicUrls[0];
 	if (url === undefined) {
 		throw new Error("Tunnel did not provide any public URLs.");
 	}
 
-	const hostnames = urls.map((publicUrl) => {
-		return new URL(publicUrl).hostname;
-	});
-	const hostname = new URL(url).hostname;
-
-	return {
-		urls,
-		url,
-		hostnames,
-		hostname,
-		origin: options.origin,
-		mode: options.mode,
-		kind: options.kind,
-		name: options.name,
-	};
-}
-
-function publishTunnelEnv(env: TunnelConfig["env"], url: string): void {
-	if (!env) {
-		return;
-	}
-
-	const names = Array.isArray(env) ? env : [env];
-	for (const name of names) {
-		process.env[name] = url;
-	}
-}
-
-async function notifyTunnelReady(options: {
-	ctx: PluginContext;
-	publicUrls: string[];
-	origin: string;
-	mode: TunnelMode;
-	kind: TunnelKind;
-}): Promise<void> {
-	const tunnel = options.ctx.resolvedPluginConfig.tunnel;
-	const readyContext = createTunnelReadyContext({
-		publicUrls: options.publicUrls,
-		origin: options.origin,
-		mode: options.mode,
-		kind: options.kind,
-		name: tunnel.name,
-	});
-
-	publishTunnelEnv(tunnel.env, readyContext.url);
-	await tunnel.onReady?.(readyContext);
+	process.env[DEFAULT_TUNNEL_URL_ENV] = url;
 }
 
 export async function setupDevTunnel(
@@ -536,13 +478,9 @@ export async function setupDevTunnel(
 		await server.restart();
 	}
 
-	await notifyTunnelReady({
-		ctx,
-		publicUrls,
-		origin,
-		mode: "dev",
-		kind: result.kind,
-	});
+	if (tunnel.autoStart) {
+		publishDefaultTunnelUrl(publicUrls);
+	}
 
 	if (shortcutPressed) {
 		server.printUrls();
@@ -600,13 +538,9 @@ export async function setupPreviewTunnel(
 		return;
 	}
 
-	await notifyTunnelReady({
-		ctx,
-		publicUrls: result.publicUrls,
-		origin,
-		mode: "preview",
-		kind: result.kind,
-	});
+	if (tunnel.autoStart) {
+		publishDefaultTunnelUrl(result.publicUrls);
+	}
 
 	if (shortcutPressed) {
 		server.printUrls();

--- a/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
@@ -7,6 +7,12 @@ import * as wrangler from "wrangler";
 import { assertIsNotPreview, assertIsPreview } from "../context";
 import { debuglog, createPlugin } from "../utils";
 import type { PluginContext } from "../context";
+import type {
+	TunnelConfig,
+	TunnelKind,
+	TunnelMode,
+	TunnelReadyContext,
+} from "../plugin-config";
 import type { Tunnel } from "@cloudflare/workers-utils";
 import type * as vite from "vite";
 
@@ -68,6 +74,11 @@ export const QUICK_TUNNEL_SSE_WARNING =
 
 export const QUICK_TUNNEL_ALLOWED_HOST = ".trycloudflare.com";
 
+interface TunnelStartResult {
+	publicUrls: string[];
+	kind: TunnelKind;
+}
+
 export class TunnelManager {
 	#logger: vite.Logger;
 	#origin?: string;
@@ -110,7 +121,7 @@ export class TunnelManager {
 		allowedHosts: true | string[] | undefined;
 		accountId: string | undefined;
 		complianceRegion: wrangler.Unstable_Config["compliance_region"];
-	}): Promise<string[] | null> {
+	}): Promise<TunnelStartResult | null> {
 		try {
 			const previousTunnel = this.#tunnel;
 
@@ -210,7 +221,7 @@ export class TunnelManager {
 		}
 	}
 
-	async #waitForPublicUrls(tunnel: Tunnel): Promise<string[] | null> {
+	async #waitForPublicUrls(tunnel: Tunnel): Promise<TunnelStartResult | null> {
 		try {
 			const result = await tunnel.ready();
 			if (this.#tunnel !== tunnel) {
@@ -222,14 +233,15 @@ export class TunnelManager {
 			}
 
 			if (result.mode === "named") {
-				return this.#publicUrls ?? null;
+				const publicUrls = this.#publicUrls;
+				return publicUrls ? { publicUrls, kind: "named" } : null;
 			}
 
 			const { publicUrl } = result;
 
 			debuglog("Tunnel is ready with public URL:", publicUrl);
 			this.#publicUrls = [publicUrl.toString()];
-			return this.#publicUrls;
+			return { publicUrls: this.#publicUrls, kind: "quick" };
 		} catch (error) {
 			if (this.#tunnel !== tunnel) {
 				return null;
@@ -419,6 +431,67 @@ export async function resolvePreviewTunnelOrigin(server: vite.PreviewServer) {
 	);
 }
 
+function createTunnelReadyContext(options: {
+	publicUrls: string[];
+	origin: string;
+	mode: TunnelMode;
+	kind: TunnelKind;
+	name?: string;
+}): TunnelReadyContext {
+	const urls = [...options.publicUrls];
+	const url = urls[0];
+	if (url === undefined) {
+		throw new Error("Tunnel did not provide any public URLs.");
+	}
+
+	const hostnames = urls.map((publicUrl) => {
+		return new URL(publicUrl).hostname;
+	});
+	const hostname = new URL(url).hostname;
+
+	return {
+		urls,
+		url,
+		hostnames,
+		hostname,
+		origin: options.origin,
+		mode: options.mode,
+		kind: options.kind,
+		name: options.name,
+	};
+}
+
+function publishTunnelEnv(env: TunnelConfig["env"], url: string): void {
+	if (!env) {
+		return;
+	}
+
+	const names = Array.isArray(env) ? env : [env];
+	for (const name of names) {
+		process.env[name] = url;
+	}
+}
+
+async function notifyTunnelReady(options: {
+	ctx: PluginContext;
+	publicUrls: string[];
+	origin: string;
+	mode: TunnelMode;
+	kind: TunnelKind;
+}): Promise<void> {
+	const tunnel = options.ctx.resolvedPluginConfig.tunnel;
+	const readyContext = createTunnelReadyContext({
+		publicUrls: options.publicUrls,
+		origin: options.origin,
+		mode: options.mode,
+		kind: options.kind,
+		name: tunnel.name,
+	});
+
+	publishTunnelEnv(tunnel.env, readyContext.url);
+	await tunnel.onReady?.(readyContext);
+}
+
 export async function setupDevTunnel(
 	server: vite.ViteDevServer,
 	ctx: PluginContext,
@@ -433,7 +506,7 @@ export async function setupDevTunnel(
 		return;
 	}
 
-	const publicUrls = await manager.startTunnel({
+	const result = await manager.startTunnel({
 		mode: "dev",
 		origin,
 		shortcutPressed,
@@ -444,16 +517,24 @@ export async function setupDevTunnel(
 		allowedHosts: true,
 	});
 
-	if (!publicUrls) {
+	if (!result) {
 		// This happens if the tunnel was restarted with a different origin before the first tunnel finished starting.
 		// In this case, we don't want to log anything since the new tunnel will log its own URL once it's ready.
 		return;
 	}
 
+	const publicUrls = result.publicUrls;
 	const allowedHosts = server.config.server.allowedHosts;
 	const tunnelHostnames = publicUrls.map((url) => new URL(url).hostname);
 
 	ctx.replaceTunnelHostnames(tunnelHostnames);
+	await notifyTunnelReady({
+		ctx,
+		publicUrls,
+		origin,
+		mode: "dev",
+		kind: result.kind,
+	});
 
 	if (
 		allowedHosts !== true &&
@@ -504,7 +585,7 @@ export async function setupPreviewTunnel(
 		return;
 	}
 
-	const publicUrls = await manager.startTunnel({
+	const result = await manager.startTunnel({
 		mode: "preview",
 		origin,
 		shortcutPressed,
@@ -514,9 +595,17 @@ export async function setupPreviewTunnel(
 		complianceRegion: ctx.allWorkerConfigs[0]?.compliance_region,
 	});
 
-	if (!publicUrls) {
+	if (!result) {
 		return;
 	}
+
+	await notifyTunnelReady({
+		ctx,
+		publicUrls: result.publicUrls,
+		origin,
+		mode: "preview",
+		kind: result.kind,
+	});
 
 	if (shortcutPressed) {
 		server.printUrls();

--- a/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
+++ b/packages/vite-plugin-cloudflare/src/plugins/tunnel.ts
@@ -528,13 +528,6 @@ export async function setupDevTunnel(
 	const tunnelHostnames = publicUrls.map((url) => new URL(url).hostname);
 
 	ctx.replaceTunnelHostnames(tunnelHostnames);
-	await notifyTunnelReady({
-		ctx,
-		publicUrls,
-		origin,
-		mode: "dev",
-		kind: result.kind,
-	});
 
 	if (
 		allowedHosts !== true &&
@@ -542,6 +535,14 @@ export async function setupDevTunnel(
 	) {
 		await server.restart();
 	}
+
+	await notifyTunnelReady({
+		ctx,
+		publicUrls,
+		origin,
+		mode: "dev",
+		kind: result.kind,
+	});
 
 	if (shortcutPressed) {
 		server.printUrls();

--- a/packages/vite-plugin-cloudflare/src/websockets.ts
+++ b/packages/vite-plugin-cloudflare/src/websockets.ts
@@ -55,12 +55,13 @@ export function handleWebSocket(
 				: `${protocol}//${rawHost}`;
 			const url = new URL(request.url ?? "", base);
 
-			const isViteRequest =
-				request.headers["sec-websocket-protocol"]?.startsWith("vite");
 			const isSandboxRequest = hasSandboxOrigin(url.origin);
 
-			// Ignore Vite HMR WebSockets but forward on all sandbox requests.
-			if (isViteRequest && !isSandboxRequest) {
+			// Ignore Vite/Vitest-owned WebSockets but forward on all sandbox requests.
+			if (
+				shouldPassThroughWebSocketUpgrade(request, url) &&
+				!isSandboxRequest
+			) {
 				return;
 			}
 
@@ -116,6 +117,40 @@ const EXCLUDED_RESPONSE_HEADERS = new Set([
 	"transfer-encoding",
 	"upgrade",
 ]);
+
+const VITEST_BROWSER_RPC_WEBSOCKET_PROTOCOL = "vitest-browser-rpc";
+const VITEST_BROWSER_API_PATHNAME = "/__vitest_browser_api__";
+
+function shouldPassThroughWebSocketUpgrade(
+	request: IncomingMessage,
+	url: URL
+): boolean {
+	return isViteRequest(request) || isVitestBrowserRpcRequest(request, url);
+}
+
+function isViteRequest(request: IncomingMessage): boolean {
+	return request.headers["sec-websocket-protocol"]?.startsWith("vite") ?? false;
+}
+
+function isVitestBrowserRpcRequest(
+	request: IncomingMessage,
+	url: URL
+): boolean {
+	return (
+		getWebSocketProtocols(request).includes(
+			VITEST_BROWSER_RPC_WEBSOCKET_PROTOCOL
+		) || url.pathname === VITEST_BROWSER_API_PATHNAME
+	);
+}
+
+function getWebSocketProtocols(request: IncomingMessage): string[] {
+	return (
+		request.headers["sec-websocket-protocol"]
+			?.split(",")
+			.map((protocol) => protocol.trim())
+			.filter(Boolean) ?? []
+	);
+}
 
 function appendWorkerResponseHeaders(
 	responseHeaders: string[],

--- a/packages/workers-utils/src/tunnel.ts
+++ b/packages/workers-utils/src/tunnel.ts
@@ -12,11 +12,13 @@ const DEFAULT_TUNNEL_EXPIRY_MS = 60 * 60 * 1_000;
 const DEFAULT_TUNNEL_EXTENSION_MS = 60 * 60 * 1_000;
 const DEFAULT_TUNNEL_MAX_REMAINING_MS = 3 * 60 * 60 * 1_000;
 const DEFAULT_TUNNEL_REMINDER_INTERVAL_MS = 10 * 60 * 1_000;
+const QUICK_TUNNEL_PROPAGATION_DELAY_MS = 10_000;
 
 /**
  * cloudflared logs the quick tunnel URL to stderr.
  */
 const QUICK_TUNNEL_URL_REGEX = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
+const TUNNEL_CONNECTION_READY_REGEX = /\bRegistered tunnel connection\b/;
 
 export interface QuickTunnelResult {
 	mode: "quick";
@@ -47,12 +49,12 @@ export interface TunnelOptions {
 }
 
 /**
- * Start a Cloudflare Quick Tunnel for a local dev origin.
+ * Start a Cloudflare Tunnel for a local dev origin.
  *
- * Spawns `cloudflared tunnel --url <origin>` and waits for the public URL
- * to appear in its stderr output. Returns a controller with a `ready()`
- * promise that resolves once the tunnel URL is available, and a `dispose()`
- * function to stop the tunnel.
+ * Spawns cloudflared and waits for it to register an edge connection. Quick
+ * tunnels also wait for the public URL to appear in stderr and a short
+ * propagation window before reporting readiness. Returns a controller with a
+ * `ready()` promise and a `dispose()` function to stop the tunnel.
  */
 export function startTunnel(options: TunnelOptions): Tunnel {
 	let disposed = false;
@@ -90,16 +92,13 @@ export function startTunnel(options: TunnelOptions): Tunnel {
 	});
 
 	const readyPromise = cloudflaredPromise
-		.then((process) => {
-			if (isNamedTunnel) {
-				return { mode: "named" } as const;
-			}
-
-			return waitForQuickTunnelReady(process, timeoutMs, {
+		.then((process) =>
+			waitForTunnelReady(process, timeoutMs, {
 				logger,
 				origin: options.origin,
-			});
-		})
+				isNamedTunnel,
+			})
+		)
 		.then((result) => {
 			expiresAt = Date.now() + defaultExpiryMs;
 
@@ -246,21 +245,67 @@ function terminateCloudflared(cloudflared: ChildProcess) {
 	forceKillTimer.unref();
 }
 
-function waitForQuickTunnelReady(
+function waitForTunnelReady(
 	cloudflared: ChildProcess,
 	timeoutMs: number,
-	options: { logger?: Pick<Logger, "debug" | "log" | "warn">; origin: URL }
+	options: {
+		logger?: Pick<Logger, "debug" | "log" | "warn">;
+		origin: URL;
+		isNamedTunnel: boolean;
+	}
 ): Promise<TunnelResult> {
 	return new Promise<TunnelResult>((resolve, reject) => {
 		let resolved = false;
+		let hasRegisteredConnection = false;
+		let publicUrl: URL | undefined;
+		let propagationTimeoutId: ReturnType<typeof setTimeout> | undefined;
 		let stderrOutput = "";
 		const logger = options?.logger;
 		const origin = options?.origin;
+		const isNamedTunnel = options?.isNamedTunnel;
+
+		function resolveReady(result: TunnelResult) {
+			resolved = true;
+			clearTimeout(timeoutId);
+			if (propagationTimeoutId) {
+				clearTimeout(propagationTimeoutId);
+			}
+			resolve(result);
+		}
+
+		function rejectReady(error: Error) {
+			resolved = true;
+			clearTimeout(timeoutId);
+			if (propagationTimeoutId) {
+				clearTimeout(propagationTimeoutId);
+			}
+			reject(error);
+		}
+
+		function maybeResolve() {
+			if (resolved || propagationTimeoutId || !hasRegisteredConnection) {
+				return;
+			}
+
+			if (isNamedTunnel) {
+				resolveReady({ mode: "named" });
+				return;
+			}
+
+			if (publicUrl) {
+				clearTimeout(timeoutId);
+				propagationTimeoutId = setTimeout(() => {
+					if (publicUrl) {
+						resolveReady({ mode: "quick", publicUrl });
+					}
+				}, QUICK_TUNNEL_PROPAGATION_DELAY_MS);
+			}
+		}
+
 		const timeoutId = setTimeout(() => {
 			if (!resolved) {
-				resolved = true;
 				terminateCloudflared(cloudflared);
-				reject(
+				rejectReady(
 					createTunnelStartupError(
 						`Timed out waiting for cloudflared to start (${timeoutMs / 1_000}s).`,
 						stderrOutput,
@@ -277,33 +322,32 @@ function waitForQuickTunnelReady(
 				stderrOutput += chunk;
 				logger?.debug("[cloudflared]", chunk.trimEnd());
 
-				const match = QUICK_TUNNEL_URL_REGEX.exec(stderrOutput);
-				if (match && !resolved) {
-					resolved = true;
-					clearTimeout(timeoutId);
-					resolve({ mode: "quick", publicUrl: new URL(match[0]) });
+				if (!isNamedTunnel && !publicUrl) {
+					const match = QUICK_TUNNEL_URL_REGEX.exec(stderrOutput);
+					if (match) {
+						publicUrl = new URL(match[0]);
+					}
 				}
+
+				hasRegisteredConnection ||=
+					TUNNEL_CONNECTION_READY_REGEX.test(stderrOutput);
+				maybeResolve();
 			});
 		}
 
 		cloudflared.on("error", (error) => {
 			if (!resolved) {
-				resolved = true;
-				clearTimeout(timeoutId);
-				reject(new Error(`Failed to start cloudflared: ${error.message}`));
+				rejectReady(new Error(`Failed to start cloudflared: ${error.message}`));
 			}
 		});
 
 		cloudflared.on("exit", (code, signal) => {
 			if (!resolved) {
-				resolved = true;
-				clearTimeout(timeoutId);
-
 				const reason = signal
 					? `terminated by signal ${signal}`
 					: `exited with code ${code}`;
 
-				reject(
+				rejectReady(
 					createTunnelStartupError(
 						`cloudflared ${reason} before the tunnel was ready.`,
 						stderrOutput,

--- a/packages/workers-utils/tests/tunnel.test.ts
+++ b/packages/workers-utils/tests/tunnel.test.ts
@@ -48,6 +48,15 @@ function emitStderrNextTick(
 	});
 }
 
+function emitRegisteredConnectionNextTick(
+	proc: ReturnType<typeof createMockProcess>
+) {
+	return emitStderrNextTick(
+		proc,
+		"2024-01-15T10:30:00Z INF Registered tunnel connection connIndex=0\n"
+	);
+}
+
 function emitNextTick(
 	proc: ReturnType<typeof createMockProcess>,
 	event: string,
@@ -62,6 +71,21 @@ function emitNextTick(
 }
 
 const TEST_TIMEOUT_MS = 60_000;
+const QUICK_TUNNEL_PROPAGATION_DELAY_MS = 10_000;
+
+async function advanceQuickTunnelPropagationDelay() {
+	await Promise.resolve();
+	await vi.advanceTimersByTimeAsync(QUICK_TUNNEL_PROPAGATION_DELAY_MS);
+}
+
+async function emitQuickTunnelReadyNextTick(
+	proc: ReturnType<typeof createMockProcess>,
+	urlLog: string
+) {
+	await emitStderrNextTick(proc, urlLog);
+	await emitRegisteredConnectionNextTick(proc);
+	await advanceQuickTunnelPropagationDelay();
+}
 
 describe("startTunnel", () => {
 	beforeEach(() => {
@@ -83,7 +107,7 @@ describe("startTunnel", () => {
 		});
 		onTestFinished(() => tunnel.dispose());
 
-		await emitStderrNextTick(
+		await emitQuickTunnelReadyNextTick(
 			proc,
 			"2024-01-15T10:30:00Z INF | https://foo-bar-baz.trycloudflare.com |\n"
 		);
@@ -94,7 +118,46 @@ describe("startTunnel", () => {
 		});
 	});
 
-	it("should resolve named tunnels after spawning cloudflared", async ({
+	it("should wait for a registered connection after the public URL", async ({
+		expect,
+	}) => {
+		const proc = createMockProcess();
+		vi.mocked(spawnCloudflared).mockResolvedValue(proc as never);
+
+		const tunnel = startTunnel({
+			origin: new URL("http://localhost:8787"),
+			timeoutMs: TEST_TIMEOUT_MS,
+		});
+		onTestFinished(() => tunnel.dispose());
+
+		let resolved = false;
+		const readyPromise = tunnel.ready().then((result) => {
+			resolved = true;
+			return result;
+		});
+
+		await emitStderrNextTick(
+			proc,
+			"2024-01-15T10:30:00Z INF | https://foo-bar-baz.trycloudflare.com |\n"
+		);
+		await Promise.resolve();
+
+		expect(resolved).toBe(false);
+
+		await emitRegisteredConnectionNextTick(proc);
+		await Promise.resolve();
+
+		expect(resolved).toBe(false);
+
+		await advanceQuickTunnelPropagationDelay();
+
+		await expect(readyPromise).resolves.toEqual({
+			mode: "quick",
+			publicUrl: new URL("https://foo-bar-baz.trycloudflare.com"),
+		});
+	});
+
+	it("should resolve named tunnels after registering a connection", async ({
 		expect,
 	}) => {
 		const proc = createMockProcess();
@@ -106,6 +169,7 @@ describe("startTunnel", () => {
 			timeoutMs: TEST_TIMEOUT_MS,
 		});
 		onTestFinished(() => tunnel.dispose());
+		await emitRegisteredConnectionNextTick(proc);
 
 		await expect(tunnel.ready()).resolves.toEqual({ mode: "named" });
 	});
@@ -119,7 +183,7 @@ describe("startTunnel", () => {
 			timeoutMs: TEST_TIMEOUT_MS,
 		});
 
-		await emitStderrNextTick(
+		await emitQuickTunnelReadyNextTick(
 			proc,
 			"INF https://test-tunnel.trycloudflare.com\n"
 		);
@@ -141,6 +205,7 @@ describe("startTunnel", () => {
 			timeoutMs: TEST_TIMEOUT_MS,
 		});
 
+		await emitRegisteredConnectionNextTick(proc);
 		await tunnel.ready();
 
 		expect(spawnCloudflared).toHaveBeenCalledWith(
@@ -235,7 +300,10 @@ describe("startTunnel", () => {
 			timeoutMs: TEST_TIMEOUT_MS,
 		});
 
-		await emitStderrNextTick(proc, "INF https://my-tunnel.trycloudflare.com\n");
+		await emitQuickTunnelReadyNextTick(
+			proc,
+			"INF https://my-tunnel.trycloudflare.com\n"
+		);
 		await tunnel.ready();
 		tunnel.dispose();
 
@@ -255,7 +323,10 @@ describe("startTunnel", () => {
 			timeoutMs: TEST_TIMEOUT_MS,
 		});
 
-		await emitStderrNextTick(proc, "INF https://my-tunnel.trycloudflare.com\n");
+		await emitQuickTunnelReadyNextTick(
+			proc,
+			"INF https://my-tunnel.trycloudflare.com\n"
+		);
 		await tunnel.ready();
 
 		tunnel.dispose();
@@ -309,7 +380,7 @@ describe("startTunnel", () => {
 		});
 
 		await emitStderrNextTick(proc, "INF https://split-");
-		await emitStderrNextTick(proc, "url-tunnel.trycloudflare.com\n");
+		await emitQuickTunnelReadyNextTick(proc, "url-tunnel.trycloudflare.com\n");
 
 		await expect(tunnel.ready()).resolves.toEqual({
 			mode: "quick",
@@ -382,7 +453,10 @@ describe("startTunnel", () => {
 			logger,
 		});
 
-		await emitStderrNextTick(proc, "INF https://my-tunnel.trycloudflare.com\n");
+		await emitQuickTunnelReadyNextTick(
+			proc,
+			"INF https://my-tunnel.trycloudflare.com\n"
+		);
 		await tunnel.ready();
 
 		await vi.advanceTimersByTimeAsync(60_000);
@@ -414,7 +488,10 @@ describe("startTunnel", () => {
 			logger,
 		});
 
-		await emitStderrNextTick(proc, "INF https://my-tunnel.trycloudflare.com\n");
+		await emitQuickTunnelReadyNextTick(
+			proc,
+			"INF https://my-tunnel.trycloudflare.com\n"
+		);
 		await tunnel.ready();
 
 		await vi.advanceTimersByTimeAsync(60_000);
@@ -455,7 +532,10 @@ describe("startTunnel", () => {
 			logger,
 		});
 
-		await emitStderrNextTick(proc, "INF https://my-tunnel.trycloudflare.com\n");
+		await emitQuickTunnelReadyNextTick(
+			proc,
+			"INF https://my-tunnel.trycloudflare.com\n"
+		);
 		await tunnel.ready();
 		tunnel.extendExpiry();
 		tunnel.extendExpiry();


### PR DESCRIPTION
Adds the minimal Vite plugin tunnel support needed by remote-browser consumers such as Vitest Browser Mode.

This PR is intended for tools that start `vite dev`, need a public origin as soon as the tunnel is usable, and cannot scrape terminal output reliably.

## Public API

Auto-started Vite plugin tunnels now publish the primary public tunnel URL to `process.env.CLOUDFLARE_TUNNEL_URL` when the tunnel is ready:

```ts
import { cloudflare } from "@cloudflare/vite-plugin";
import { defineConfig } from "vite";

export default defineConfig({
  plugins: [
    cloudflare({
      tunnel: {
        autoStart: true,
      },
    }),
  ],
});
```

Consumers running in the same Node process can read the URL after the dev server has started:

```ts
const publicOrigin = process.env.CLOUDFLARE_TUNNEL_URL;
```

Named tunnels also publish the first resolved public URL to `CLOUDFLARE_TUNNEL_URL`.

## Behavioral Details

For dev tunnels, `CLOUDFLARE_TUNNEL_URL` is published only after any required Vite dev-server restart for `server.allowedHosts`. This avoids handing consumers a URL before the restarted server can accept requests for the tunnel hostname.

Quick tunnel readiness now waits for cloudflared to log a registered edge connection and then waits a short propagation window before reporting the URL. This avoids publishing a URL immediately after cloudflared prints it, when remote clients can still see transient connection resets.

The Vite plugin now also passes through Vitest Browser Mode's browser RPC WebSocket upgrades. Requests with subprotocol `vitest-browser-rpc` or path `/__vitest_browser_api__` are left for Vite/Vitest to handle instead of being forwarded to the Worker. Normal Worker WebSocket upgrades still dispatch to Miniflare, and the existing Vite HMR and Sandbox SDK behavior is preserved.

## Vitest Browser Mode Example

Downstream config can now rely on the default environment variable:

```ts
import { cloudflare } from "@cloudflare/vite-plugin";
import { defineConfig } from "vitest/config";

import { browserRunCdp } from "@vitest-browser-run/browser-run-provider";

export default defineConfig({
  plugins: [cloudflare({ tunnel: { autoStart: true } })],
  test: {
    browser: {
      enabled: true,
      provider: browserRunCdp(),
    },
  },
});
```

The downstream provider can read `process.env.CLOUDFLARE_TUNNEL_URL`; prior downstream verification passed `pnpm typecheck && pnpm test:browser-run` with 10 browser tests.

---

- Tests
  - [x] Tests included/updated
  - [ ] Automated tests not possible - manual testing has been completed as follows:
  - [ ] Additional testing not necessary because:
- Public documentation
  - [ ] Cloudflare docs PR(s): <!--e.g. <https://github.com/cloudflare/cloudflare-docs/pull/>...-->
  - [x] Documentation not necessary because: Package README documentation is included in this PR; developer docs can follow after the API lands.

*A picture of a cute animal (not mandatory, but encouraged)*
